### PR TITLE
full integration with Startup Notification Library for hourglass #479

### DIFF
--- a/idesk/ideskrc
+++ b/idesk/ideskrc
@@ -16,6 +16,7 @@ table Config
   ShadowY: 1
   Bold: true
   ClickDelay: 300
+  IconStartDelay: 5000
   IconSnap: true
   SnapWidth: 10
   SnapHeight: 10

--- a/src/Makefile
+++ b/src/Makefile
@@ -28,8 +28,8 @@ $(TARGET): main.o icon.o background.o configuration.o desktop.o
 icon.o: icon.cpp icon.h logging.h configuration.h
 	g++ -c $(DEBUGGING) $(XFTINC) icon.cpp
 
-main.o: main.cpp main.h configuration.h logging.h
-	g++ -c $(DEBUGGING) $(XFTINC) main.cpp
+main.o: main.cpp main.h configuration.h logging.h version.h
+	g++ -c $(DEBUGGING) $(XFTINC) $(SNINC) main.cpp
 
 background.o: background.cpp logging.h
 	g++ -c $(DEBUGGING) background.cpp
@@ -37,5 +37,5 @@ background.o: background.cpp logging.h
 configuration.o: configuration.cpp configuration.h logging.h
 	g++ -c $(DEBUGGING) configuration.cpp
 
-desktop.o: desktop.cpp desktop.h logging.h configuration.h
+desktop.o: desktop.cpp desktop.h logging.h configuration.h sn_callbacks.cpp
 	g++ -c $(DEBUGGING) $(XFTINC) $(SNINC) desktop.cpp

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -76,6 +76,11 @@ bool Configuration::load_conf(const char *filename)
 	ifile >> value;
 	configuration["clickdelay"] = value;
       }
+
+      if (token == "IconStartDelay:") {
+	ifile >> value;
+	configuration["iconstartdelay"] = value;
+      }
     }
  
   ifile.close();

--- a/src/desktop.h
+++ b/src/desktop.h
@@ -7,6 +7,14 @@
 // An app to show and bring life to Kano-Make Desktop Icons.
 //
 
+//
+// TODO: Always keep an eye on libsn upgrades.
+// This API library is not officially conformed across different architectures
+// See the file:  /usr/include/startup-notification-1.0/libsn/sn-common.h for details
+//
+#define SN_API_NOT_YET_FROZEN
+#include <libsn/sn.h>
+
 class Desktop
 {
  private:
@@ -15,19 +23,19 @@ class Desktop
   SnLauncherContext *sn_context;
   Configuration *pconf;
   bool finish;
+  static int error_trap_depth;
 
  public:
   Desktop(Configuration *loaded_conf);
   virtual ~Desktop(void);
 
   bool create_icons (Display *display);
-  bool notify_hourglass_start (Display *display, int iconid, Time time);
-  bool notify_hourglass_end (Display *display, int iconid, Time time);
+
+  bool notify_startup_load (Display *display, int iconid, Time time);
+  bool notify_startup_ready (Display *display);
+  void notify_startup_event (Display *display, XEvent *pev);
+
   bool process_and_dispatch(Display *display);
   bool finalize(void);
 
-  /*
-  void error_trap_push (SnDisplay *display, Display   *xdisplay);
-  void error_trap_pop (SnDisplay *display, Display   *xdisplay);
-  */
 };

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -63,9 +63,7 @@ bool Icon::is_singleton_running (void)
 	bAppRunning = false;
 	cout << "app " << appid << " is NOT running" << endl;
       }
-
     }
-
   return bAppRunning;
 }
 

--- a/src/sn_callbacks.cpp
+++ b/src/sn_callbacks.cpp
@@ -1,0 +1,45 @@
+//
+// sn_callbacks.cpp
+//
+// Copyright (C) 2013-2014 Kano Computing Ltd.
+// License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+//
+// An app to show and bring life to Kano-Make Desktop Icons.
+//
+
+//
+// The following module provides for sn_notify framework callback functions
+// to handle event errors.
+//
+// TODO: Always keep an eye on libsn upgrades.
+// This API library is not officially conformed across different architectures
+// See the file:  /usr/include/startup-notification-1.0/libsn/sn-common.h for details
+//
+
+#define SN_API_NOT_YET_FROZEN
+#include <libsn/sn.h>
+
+#include "logging.h"
+
+unsigned int error_trap_depth;
+
+void error_trap_push (SnDisplay *display, Display *xdisplay);
+void error_trap_pop (SnDisplay *display, Display *xdisplay);
+
+void error_trap_push (SnDisplay *display, Display *xdisplay)
+{
+  log("error_trap_push incrementing");
+  ++error_trap_depth;
+}
+
+void error_trap_pop (SnDisplay *display, Display *xdisplay)
+{
+  log ("error_trap_pop call");
+  if (error_trap_depth == 0)
+    {
+      log("fatal error trap underflow - the x11 event chain is hurt");
+    }
+  
+  XSync (xdisplay, False); /* get all errors out of the queue */
+  --error_trap_depth;
+}

--- a/src/version.h
+++ b/src/version.h
@@ -7,4 +7,4 @@
 // An app to show and bring life to Kano-Make Desktop Icons.
 //
 
-#define VERSION "1.00"
+#define VERSION "1.01"


### PR DESCRIPTION
- fixed sn_context object used to tell when and which app is going to start
- decoupled static methods in a separate module sn_callbacks
- added a new configuration setting IconStartDelay to disable all icons upon app startup
- increased version number
