### PR TITLE
Teaching debuild to compile and distribute kdesk, replacement to idesk

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Team Kano <dev@kano.me>
 Section: x11
 Priority: optional
 Standards-Version: 3.9.4
-Build-Depends: debhelper (>=9.0.0)
+Build-Depends: libx11-dev, libxft-dev, libstartup-notification0-dev, debhelper (>=9.0.0)
 
 Package: kano-desktop
 Architecture: all

--- a/debian/install
+++ b/debian/install
@@ -26,3 +26,5 @@ extras/* usr/share/kano-desktop/extras
 idesk/* usr/share/kano-desktop/idesk
 
 fonts/* usr/share/fonts/kanux
+
+src/kdesk /usr/bin

--- a/debian/rules
+++ b/debian/rules
@@ -2,3 +2,7 @@
 
 %:
 	dh $@
+
+# The desktop icon manager kdesk
+
+	cd src && make -B

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@ LIBS:=-lXft -lImlib2 -lstdc++ `pkg-config --libs libstartup-notification-1.0`
 XFTINC:=-I/usr/include/freetype2
 SNINC=-I/usr/include/startup-notification-1.0
 
-TARGET=kano-desktop
+TARGET=kdesk
 
 all: $(TARGET)
 


### PR DESCRIPTION
- added build dependency packages
- changed binary name to kdesk
- force a source build for release - no symbolic info, no logging
- binary installation in /usr/bin
