### PR TITLE
Telling pcmanfm to use gksudo coorectly

### DIFF
--- a/config/pcmanfm/default/pcmanfm.conf
+++ b/config/pcmanfm/default/pcmanfm.conf
@@ -1,6 +1,6 @@
 [config]
 bm_open_method=0
-su_cmd=gksu -s -k -S %s
+su_cmd=gksu -g -k -S %s
 
 [desktop]
 wallpaper_mode=1


### PR DESCRIPTION
- Disable mouse grabbing, it is not compatible with our combination of openbox/lightdm
  and complains with a fatal error
- Force to inherit user's environment
- Use sudo rather than su, so the regular user's password is used to switch root permissions
