### PR TITLE
Removing unused items from the Greeter's login dialog

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -80,13 +80,27 @@ case "$1" in
 
         # Remove all but our default Ligtdhm Xsession from the Greeter login dialog
         # these are displayed under the password field, in a drop down list
-        dir_xsession=/usr/share/xsession
-        dir_xsession_disabled=/usr/share/xsession/disabled
-        mkdir -p $dir_xsession_disabled
-        mv $dir_xsession/LXDE.desktop $dir_xsession_disabled
-        mv $dir_xsession/openbox-gnome.desktop $dir_xsession_disabled
-        mv $dir_xsession/openbox-kde.desktop $dir_xsession_disabled
-        mv $dir_xsession/openbox.desktop $dir_xsession_disabled
+        dir_xsession=/usr/share/xsessions
+        dir_xsession_disabled=/usr/share/xsessions/disabled
+        if [ ! -d $dir_xsession_disabled ]; then
+            mkdir -p $dir_xsession_disabled
+        fi
+
+        if [ -f $dir_xsession/LXDE.desktop ]; then
+            mv $dir_xsession/LXDE.desktop $dir_xsession_disabled
+        fi
+
+        if [ -f $dir_xsession/openbox-gnome.desktop ]; then
+            mv $dir_xsession/openbox-gnome.desktop $dir_xsession_disabled
+        fi
+
+        if [ -f $dir_xsession/openbox-kde.desktop ]; then
+            mv $dir_xsession/openbox-kde.desktop $dir_xsession_disabled
+        fi
+
+        if [ -f $dir_xsession/openbox.desktop ]; then
+            mv $dir_xsession/openbox.desktop $dir_xsession_disabled
+        fi
 
         # Configure chromium
         cp $chromium_master_prefs $chromium_master_prefs-old


### PR DESCRIPTION
- All session types except lightdm (default) are moved to
  a directory called "disabled" so they are not displayed on the Greeter's login dialog
