### PR TITLE
Adding an alias to shut espeak

### DIFF
--- a/config/profile/kano-bashrc
+++ b/config/profile/kano-bashrc
@@ -42,7 +42,7 @@ function espeak_override()
     espeak $@ 2>/dev/null
     if [ "$?" -neq 0 ]; then
         >&2 echo "ERROR: espeak reported problems."
-        >&2 echo "Please run 'espeak_debug @$' to see the error."
+        >&2 echo "Please run 'espeak_debug $@' to see the error."
     fi
 }
 alias espeak=espeak_override


### PR DESCRIPTION
If espeak returns nonzero, it will tell the to run it with debugging on.

Related to https://github.com/KanoComputing/peldins/issues/1530

cc @alex5imon 
