### PR TITLE
kano-uixinit propagates forced logging level

### DIFF
--- a/bin/kano-uixinit
+++ b/bin/kano-uixinit
@@ -13,8 +13,6 @@
 
 . /usr/share/kano-toolset/logging.sh
 
-export LOG_LEVEL="info"
-
 first_boot_file="$HOME/.kano-settings/first_boot"
 after_update_file="$HOME/.kano-settings/after_update"
 mkdir -p "$HOME/.kano-settings"


### PR DESCRIPTION
We forced logging level in uixinit to info for 1.3.2. Unfortunately, that means that it propagates to the rest of the GUI system as everything else is a child of that script.

This commit reverses the change.

cc @alex5imon @skarbat 
