### PR TITLE
Improving the desktop hourglass during desktop bootup

### DIFF
--- a/bin/kano-uixinit
+++ b/bin/kano-uixinit
@@ -121,6 +121,10 @@ if [ ! -f $first_boot_file ] && [ "$SKIP" != "true" ]; then
     check_for_updates=0
 # The following is executed in subsequent boots
 else
+
+    # start hourglass to wait for the last X11 app to get ready
+    kdesk-hourglass-app "lxpanel"
+
     # load background
     /usr/bin/kdesk -w &
 fi
@@ -135,8 +139,6 @@ logger_info "Launching startmouse"
 # lxpanel
 logger_info "Launching LXPanel"
 
-# start hourglass to wait for the last X11 app to get ready
-kdesk-hourglass-app "kano-feedback-widget"
 /usr/bin/lxpanel --profile LXDE &
 
 # LXPanel resets the volume level to 100, we need it to be restored to


### PR DESCRIPTION
- Start the waiting hourglass a bit earlier,
  right before setting the desktop background.
- Wait for "lxpanel" instead of "desktop widget", because
  the widget does not have an identifiable name, sometimes
  it will be hidden (no questions available) and the
  hourglass would terminate by a timeout instead.
- With this change, the hourglass disappears as soon as the
  desktop icons are displayed on the desktop.

cc @alex5imon 
