### PR TITLE
uixinit: Move the updater boot check out of init

### DIFF
--- a/bin/kano-uixinit
+++ b/bin/kano-uixinit
@@ -171,7 +171,7 @@ kano-tracker-ctl +1 startup
 if [ is_internet ]; then
     if [ $check_for_updates -eq 1 ]; then
         logger_info "Checking for update"
-        sudo kano-updater check --gui &
+        sudo kano-updater check --gui --interval 168 &
     else
         logger_info "Not checking for update"
     fi


### PR DESCRIPTION
The boot check needs to be independent of Kano Desktop so that if Kano
Updater is updated but, for some reason, Kano Desktop isn't then the
updater will be able to clean up after itself.

cc @pazdera 
