### PR TITLE
Minor UI changes in Profile and World desktop icons

### DIFF
--- a/kdesk/icon-hooks.sh
+++ b/kdesk/icon-hooks.sh
@@ -50,7 +50,7 @@ case $icon_name in
         eval line_item=($item)
         case ${line_item[0]} in
             "mixed_username:")
-                username=${line_item[1]^}
+                username=${line_item[1]}
                 ;;
             "level:")
                 level=${line_item[1]}


### PR DESCRIPTION
- if Online and notifications show the number icon
- if Online and no notifications don't show anything (no number or - icon)
- if Offline show the - icon
- change LEVEL to Level
- added additional call to kano-profile-cli to query Kano World login status
