### PR TITLE
check-for-updates: Only once a week

### DIFF
--- a/kdesk/icon-hooks.sh
+++ b/kdesk/icon-hooks.sh
@@ -174,7 +174,7 @@ case $icon_name in
                 echo "starting kano-sync and checking for updates"
             fi
             kano-sync --sync --backup -s &
-            sudo /usr/bin/kano-updater check --gui --interval 24 &
+            sudo /usr/bin/kano-updater check --gui --interval 168 &
         fi
         ;;
 


### PR DESCRIPTION
Limit the screensaver-time check for updates to happen once a week only.

Related to: https://github.com/KanoComputing/kano-updater/pull/102

cc @Ealdwulf @alex5imon 
