### PR TITLE
kano-uixinit: Speed up the wallpaper screen

### DIFF
--- a/bin/kano-uixinit
+++ b/bin/kano-uixinit
@@ -114,12 +114,20 @@ if [ ! -f $first_boot_file ]; then
         if [ "$FLOW" != "workshops" ]; then
             kano-login --register
         fi
+
+        # Show the background selector from settings
+        # The process will be launched in the background while the video
+        # plays so the window is ready for the user when it's done.
+        sudo kano-settings 14 &
+        SETTINGS_PID=$!
+
         # Video
         logger_info "Playing os_intro.mp4"
         kano-video-cli /usr/share/kano-media/videos/os_intro.mp4
 
-        # Show the background selector from settings
-        sudo kano-settings 14
+        # Wait for the user to select the wallpaper and close the
+        # settings window.
+        wait $SETTINGS_PID
 
         # start hourglass to wait for the last X11 app to get ready
         kdesk-hourglass-app "lxpanel"


### PR DESCRIPTION
The wallpaper settings screen will be launched in the background while
the video plays so it's ready for the user when the playback finishes.

Tested on the Pi and it seems to work fine. The window is waiting there
when the video is over. I didn't notice any stutters/performance hit
of doing this in the video. I guess that's because it's being done on
the GPU.

Related to: https://github.com/KanoComputing/peldins/issues/1865

cc @skarbat @alex5imon 