### PR TITLE
Fix to remove erratic hourglass on lxterminal

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -105,6 +105,17 @@ case "$1" in
         # Apply Kano PAM customization to enforce umask for login sessions
         pam-auth-update --package kano-umask --force
 
+        # Fix hourglass staying too long when starting more than 1 lxterminal
+        lxterm_desktop_file='/usr/share/applications/auto_terminal.desktop'
+
+        if [ -f "$lxterm_desktop_file" ]; then
+            # then apply the patch: tell lxde to forget about it (add/force StartupNotify=false)
+            sed -i '/^StartupNotify=/{h;s/=.*/=false/};${x;/^$/{s//StartupNotify=false/;H};x}' $lxterm_desktop_file
+
+            # and wrap lxterminal inside kdesk hourglass command line tool
+            sed -i "s/Exec=.*/Exec=\/bin\/bash -c \"kdesk-hourglass-app lxterminal ; lxterminal\"/g" $lxterm_desktop_file
+        fi
+
         ;;
 esac
 

--- a/debian/postrm
+++ b/debian/postrm
@@ -66,6 +66,17 @@ case "$1" in
         sed -i "s|#\?\(session-setup-script\=\).*|#\1|" $ldm_conf
         sed -i "s|#\?\(session-cleanup-script\=\).*|#\1|" $ldm_conf
 
+        # Remove the hourglass fix when starting multiple lxterminals through desktop menu
+        lxterm_desktop_file='/usr/share/applications/auto_terminal.desktop'
+
+        if [ -f "$lxterm_desktop_file" ]; then
+            # Remove the StartupNotify flag
+            sed -i '/^StartupNotify=.*/g' $lxterm_desktop_file
+
+            # Remove Kano hourglass wrapper tool
+            sed -i "s/Exec=.*/Exec=lxterminal/g" $lxterm_desktop_file
+        fi
+
         ;;
 esac
 


### PR DESCRIPTION
 * If you open more than one lxterminal, the hourglass stays
   active for too long. This changeset fixes this problem
 * Resolved by telling lxde to not start the hourglass,
   and using kdesk command line tool counterpart instead

cc @alex5imon 