### PR TITLE
uixinit: Launch Kano World widget at startup

### DIFF
--- a/bin/kano-uixinit
+++ b/bin/kano-uixinit
@@ -144,7 +144,10 @@ logger_info "Launching kano-mount-trigger"
 # starting kdesk
 logger_info "Launching kdesk"
 /usr/bin/kdesk &
+
+# launching desktop widgets
 /usr/bin/kano-feedback-widget &
+/usr/bin/kano-world-widget &
 
 
 # Report a startup event to Kano Tracker

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Depends: ${misc:Depends}, openbox (>=3.5.2-4~kano.1),
          kano-video-files (>=1.1-2), kano-init-flow (>=2.2-1), kano-profile (>=2.1-4),
          libkdesk-dev, kano-greeter, kano-updater (>=2.2.0-1),
          kano-apps (>=2.0-1), kano-settings (>=2.0-1), kano-content, telnet,
-         kano-widgets (>=2.2-1)
+         kano-widgets (>=2.2-1), kano-applets
 Replaces: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Breaks: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Description: The desktop experience of Kanux


### PR DESCRIPTION
KanoComputing/engage#84
The new Kano World widget should be launched when the desktop is loaded
to provide the full experience.