### PR TITLE
Adding systemd config to kano dekstop

### DIFF
--- a/config/systemd/kano.conf
+++ b/config/systemd/kano.conf
@@ -1,0 +1,4 @@
+# Kano OS specific configuration for systemd
+
+[Manager]
+DefaultTimeoutStopSec=30s

--- a/debian/install
+++ b/debian/install
@@ -19,6 +19,7 @@ config/profile usr/share/kano-desktop/config
 config/rxvt/x11-rxvt etc/X11/Xresources
 config/gtk-2.0 etc/skel/.config/
 config/dconf etc/skel/.config/
+config/systemd/* usr/lib/systemd/system.conf.d
 
 videos usr/share/kano-media
 gtk-themes/Kano usr/share/themes


### PR DESCRIPTION
This sets the default stop timeout for services to 30s.

So in the worst case, the shutdown will take 30 secs.

cc @Ealdwulf @alex5imon 

Related to: https://github.com/KanoComputing/peldins/issues/2100