### PR TITLE
LXPanel Plugins: Remove kano_notifications

### DIFF
--- a/config/lxpanel/LXDE/panels/panel
+++ b/config/lxpanel/LXDE/panels/panel
@@ -90,10 +90,6 @@ Plugin {
 }
 
 Plugin {
-    type = kano_notifications
-}
-
-Plugin {
     type = kano_internet
 }
 


### PR DESCRIPTION
The `kano_notifications` plugin was migrated to a stand-alone
application but the LXPanel configuration requiring the plugin remains
meaning that an attempt is made to load it every time LXPanel is
started. Remove this from the configuration to prevent this.

cc @Ealdwulf @pazdera 