### PR TITLE
Run xcompmgr at startup if using the new driver.

### DIFF
--- a/bin/kano-uixinit
+++ b/bin/kano-uixinit
@@ -125,6 +125,9 @@ else
     /usr/bin/kdesk -w &
 fi
 
+# load compositor if the new driver is running
+(xdriinfo | grep vc4 ) && xcompmgr &
+
 # loads and sets the keyboard layout
 set_keyboard $kano_keyboard
 


### PR DESCRIPTION
This PR loads the compositor if the new driver is running, allowing  some acceleration (and right now, breaking kdesk's wallpaper handling). Note that it doesn't seem to be completely necessary for openGL (glxgears works without it). 

@tombettany @skarbat 