### PR TITLE
Teaching kano-uixinit to run in Dashboard mode

### DIFF
--- a/bin/kano-uixinit
+++ b/bin/kano-uixinit
@@ -18,6 +18,15 @@
 
 . /usr/share/kano-toolset/logging.sh
 
+# If we are in Kano v3, jump to Dashboard Mode, unless instructed otherwise
+if [ `grep -c "3.0.0" /etc/kanux_version` == "1" ] && [ "${DESKTOP_MODE}" != "1" ]; then
+    logger_info "Starting Kano v3 in Dashboard mode"
+    exec kano-dashboard-supervisor
+    exit 0
+else
+    logger_info "Starting Kano v3 in Desktop Mode"
+fi
+
 first_boot_file="$HOME/.kano-settings/first_boot"
 after_update_file="$HOME/.kano-settings/after_update"
 mkdir -p "$HOME/.kano-settings"

--- a/bin/kano-uixinit
+++ b/bin/kano-uixinit
@@ -19,12 +19,12 @@
 . /usr/share/kano-toolset/logging.sh
 
 # If we are in Kano v3, jump to Dashboard Mode, unless instructed otherwise
-if [ `grep -c "3.0.0" /etc/kanux_version` == "1" ] && [ "${DESKTOP_MODE}" != "1" ]; then
-    logger_info "Starting Kano v3 in Dashboard mode"
+if [ "${DESKTOP_MODE}" != "1" ]; then
+    logger_info "Starting in Dashboard mode"
     exec kano-dashboard-supervisor
     exit 0
 else
-    logger_info "Starting Kano v3 in Desktop Mode"
+    logger_info "Starting in Desktop Mode"
 fi
 
 first_boot_file="$HOME/.kano-settings/first_boot"

--- a/bin/kano-uixinit
+++ b/bin/kano-uixinit
@@ -18,15 +18,6 @@
 
 . /usr/share/kano-toolset/logging.sh
 
-# If we are in Kano v3, jump to Dashboard Mode, unless instructed otherwise
-if [ "${DESKTOP_MODE}" != "1" ]; then
-    logger_info "Starting in Dashboard mode"
-    exec kano-dashboard-supervisor
-    exit 0
-else
-    logger_info "Starting in Desktop Mode"
-fi
-
 first_boot_file="$HOME/.kano-settings/first_boot"
 after_update_file="$HOME/.kano-settings/after_update"
 mkdir -p "$HOME/.kano-settings"
@@ -82,6 +73,18 @@ fi
 # detect kano-keyboard
 kano_keyboard=`python -c "from kano.utils import detect_kano_keyboard; print detect_kano_keyboard()"`
 
+# loads and sets the keyboard layout
+set_keyboard $kano_keyboard
+
+# Jump to Dashboard Mode, unless instructed otherwise
+if [ "${DESKTOP_MODE}" != "1" ]; then
+    logger_info "Starting in Dashboard mode"
+    exec kano-dashboard-supervisor
+    exit 0
+else
+    logger_info "Starting in Desktop Mode"
+fi
+
 # Set the initial default volume
 if [ -e /etc/init.d/alsa-utils ]; then
     amixer -c 0 -- sset PCM 0 &> /dev/null
@@ -136,9 +139,6 @@ fi
 
 # load compositor if the new driver is running
 (xdriinfo | grep vc4 ) && xcompmgr &
-
-# loads and sets the keyboard layout
-set_keyboard $kano_keyboard
 
 # startmouse
 logger_info "Launching startmouse"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-kano-desktop (2.4.0-1) unstable; urgency=low
+kano-desktop (3.0.0-1) unstable; urgency=low
 
   * Added Launch Kano v3 Dashboard mode by default
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-desktop (2.4.0-1) unstable; urgency=low
+
+  * Added Launch Kano v3 Dashboard mode by default
+
+ -- Team Kano <dev@kano.me>  Wed, 09 Mar 2016 14:28:30 +0100
+
 kano-desktop (2.3.0-1) unstable; urgency=low
 
   * Change grid position for Scratch and Video

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Depends: ${misc:Depends}, openbox (>=3.5.2-4~kano.1),
          kano-video-files (>=1.1-2), kano-init-flow (>=2.2-1), kano-profile (>=2.2.0-4),
          libkdesk-dev, kano-greeter, kano-updater (>=2.2.0-1),
          kano-apps (>=2.0-1), kano-settings (>=2.0-1), kano-content, telnet,
-         kano-widgets (>=2.2-1), kano-applets, chromium-browser (>= 41.0)
+         kano-widgets (>=2.2-1), kano-applets, chromium-browser (>= 41.0), kano-dashboard(>=0.1)
 Replaces: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Breaks: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Description: The desktop experience of Kanux


### PR DESCRIPTION
 * If running on Kano v3, start in Dashboard mode by default
 * An environment variable will instruct it to proceed to normal Desktop mode

@tombettany this simple method would allow us to jump between Dashboard and Desktop mode.
