### PR TITLE
Dashboard Mode: Ensure tracking sync on boot

### DIFF
--- a/bin/kano-uixinit
+++ b/bin/kano-uixinit
@@ -81,14 +81,14 @@ function track_startup
 test -f /run/lock/desktop_init_run
 DESKTOP_RUN=$?
 touch /run/lock/desktop_init_run
-FIRST_BOOT=0
+FIRST_BOOT=1
 
 if [ "$DESKTOP_RUN" -eq 1 ] ; then
    logger --id --tag "info" "kano-uixinit first execution"
    # Finalise account setup
    # NB sudo costs us 1 second here, could save it by checking the
    # json file
-   sudo kano-init finalise || FIRST_BOOT=1
+   sudo kano-init finalise || FIRST_BOOT=0
 
    track_startup
 

--- a/bin/kano-uixinit
+++ b/bin/kano-uixinit
@@ -56,6 +56,24 @@ function set_keyboard
     sudo /usr/bin/kano-settings-cli set keyboard --load
 }
 
+function track_startup
+{
+    # Report a startup event to Kano Tracker
+    kano-tracker-ctl +1 startup
+
+    if [ is_internet ]; then
+        # Try uploading the tracking data to our servers
+        # Should be quiet on failure
+        kano-sync --upload-tracking-data --silent
+
+        # Sync objects from the content API in the background
+        # TODO: This should be removed once we have the daemon done
+        sudo kano-content sync &
+
+        kano-tracker-ctl +1 'internet-connection-established'
+    fi
+}
+
 ############ STARTS HERE ############
 
 # Is this the first time we executed this boot?
@@ -72,6 +90,7 @@ if [ "$DESKTOP_RUN" -eq 1 ] ; then
    # json file
    sudo kano-init finalise || FIRST_BOOT=1
 
+   track_startup
 
    if [ "$FIRST_BOOT" -eq 1 ] ; then
        # Finalise account setup
@@ -195,22 +214,6 @@ logger --id --tag "info" "Launching kdesk"
 # Starting the LED Speaker CPU Monitor animation
 # and checking kano-settings for preference setting
 kano-speakerleds cpu-monitor start --check &
-
-# Report a startup event to Kano Tracker
-kano-tracker-ctl +1 startup
-
-if [ is_internet ]; then
-    # Try uploading the tracking data to our servers
-    # Should be quiet on failure
-    kano-sync --upload-tracking-data --silent
-
-    # Sync objects from the content API in the background
-    # TODO: This should be removed once we have the daemon done
-    sudo kano-content sync &
-
-    kano-tracker-ctl +1 'internet-connection-established'
-fi
-
 
 # Remove Homedir "Desktop" folder created by:
 # /usr/share/xsessions/lightdm-xsession.desktop


### PR DESCRIPTION
Ensure that the tracking events are synced at boot. Also sync
kano-content and register a startup event.

@skarbat @Ealdwulf I included a couple of extra commands which seemed important in the dashboard init; let me know if they are unneeded.