### PR TITLE
Change console font.

### DIFF
--- a/config/console/console-setup
+++ b/config/console/console-setup
@@ -1,0 +1,17 @@
+# CONFIGURATION FILE FOR SETUPCON
+
+# Consult the console-setup(5) manual page.
+
+ACTIVE_CONSOLES="/dev/tty[1-6]"
+
+CHARMAP="UTF-8"
+
+CODESET="guess"
+FONTFACE="VGA"
+FONTSIZE="16x28"
+
+VIDEOMODE=
+
+# The following is an example how to use a braille font
+# FONT='lat9w-08.psf.gz brl-8x8.psf'
+

--- a/debian/install
+++ b/debian/install
@@ -20,6 +20,7 @@ config/rxvt/x11-rxvt etc/X11/Xresources
 config/gtk-2.0 etc/skel/.config/
 config/dconf etc/skel/.config/
 config/systemd/* usr/lib/systemd/system.conf.d
+config/console usr/share/kano-desktop/config
 
 videos usr/share/kano-media
 gtk-themes/Kano usr/share/themes

--- a/debian/postinst
+++ b/debian/postinst
@@ -129,6 +129,9 @@ case "$1" in
             sed -i "s/Exec=.*/Exec=\/bin\/bash -c \"kdesk-hourglass-app lxterminal ; lxterminal\"/g" $lxterm_desktop_file
         fi
 
+        # configure console
+        cp usr/share/kano-desktop/config/console/console-setup /etc/default/
+
         ;;
 esac
 


### PR DESCRIPTION
This changes the console font to a large size.
Kano-init is then fixed to work with this  here:  https://github.com/KanoComputing/kano-init/pull/28 