### PR TITLE
Added Make Adventures start script

### DIFF
--- a/bin/make-adventures
+++ b/bin/make-adventures
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# This script starts and controls that a single instance of Make Adventures is running.
+#
+# If another instance of Chromium is running, it is killed, and Adventures starts.
+# If Adventures is running it maximizes and focus grabbed, then returns silently.
+# Otherwise the app is launched, in maximized state.
+#
+# This script is meant to be started from the desktop icon,
+# so it needs to run as fast as possible. It also takes care of tracking.
+#
+
+import os
+import sys
+
+adventures_window_name='Kano Adventures'
+chromium_window_name='Chromium-browser'
+
+adventures_cmdline="kano-tracker-ctl session run " \
+    "kano-adventures 'x-www-browser --start-maximized http://adventures.kano.me/'"
+
+
+def get_window_name(window_name):
+    '''
+    Returns Window ID if window_name is found on the desktop.
+    '''
+    try:
+        window_id=os.popen('xdotool search --name "{}"'.format(window_name)).read()
+        if window_id and len(window_id):
+            return window_id.strip()
+    except:
+        pass
+
+    return None
+
+
+def maximize_window(window_name):
+    '''
+    Maximizes and gives focus to the window_name.
+    '''
+    os.system('wmctrl -r "{}" -b add,maximized_vert,maximized_horz'.format(window_name))
+    os.system('wmctrl -a "{}"'.format(window_name))
+
+
+if __name__ == '__main__':
+
+    # Is Make adventures already running? Bring to the front and quit asap.
+    winid=get_window_name(adventures_window_name)
+    if winid:
+        maximize_window(adventures_window_name)
+        sys.exit(0)
+
+    # Is an unrelated Chromium running? Kill it and start Make Adventures.
+    if get_window_name(chromium_window_name):
+        os.system('pkill -f chromium-browser')
+
+    rc=os.system(adventures_cmdline)
+    sys.exit(rc)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-desktop (3.1.1-1) unstable; urgency=low
+
+  * Added Make Adventures on the desktop
+
+ -- Team Kano <dev@kano.me>  Wed, 13 Apr 2016 17:28:08 +0100
+
 kano-desktop (3.0.1-1) unstable; urgency=low
 
   * Added desktop icon to switch to Dashboard mode

--- a/debian/install
+++ b/debian/install
@@ -30,6 +30,7 @@ bin/kano-uixinit usr/bin
 bin/open-me etc/skel/.Rabbithole
 bin/use-the-force usr/bin
 bin/kano-dashboard-confirm usr/bin
+bin/make-adventures usr/bin
 
 scripts/* usr/share/kano-desktop/scripts
 

--- a/kdesk/kdesktop/Adventures.lnk
+++ b/kdesk/kdesktop/Adventures.lnk
@@ -1,7 +1,7 @@
 table Icon
   Caption:
-  AppID: chromium-browser
-  Command: kano-tracker-ctl session run kano-adventures 'x-www-browser --start-maximized http://adventures.kano.me/'
+  AppID: make-adventures
+  Command: /usr/bin/make-adventures
   Singleton: true
   Icon: /usr/share/kano-video/icon/adventures.png
   IconHover: /usr/share/kano-desktop/icons/adventures-hover.png


### PR DESCRIPTION
 * A wrapper script linked to the desktop icon
 * Gives focus to the app and maximizes if already running
 * If a separate Chromium is running, it is killed, then Adventures kicks in