### PR TITLE
For now, change to kill a blacklist of daemons to avoid killing wifi.

### DIFF
--- a/scripts/ldm-session-cleanup-script
+++ b/scripts/ldm-session-cleanup-script
@@ -16,21 +16,14 @@ su - $USER -c "kano-tracker-ctl clear"
 su - $USER -c "kano-tracker-ctl new-token"
 su - $USER -c "kano-sync --upload-tracking-data --silent"
 
+
 # kill old session: kills any processes still running from
 # the old session.
 
-# Annoyingly, we are not passed our session ID. For now,
-# kill all sessions in 'closing' state
-
-# List the sessions
-SESSIONS=$(loginctl --no-legend --no-pager |awk '{print $1}')
-
-for s in $SESSIONS; do
-    # Kill if in closing state
-    STATE=$(loginctl show-session $s -p State)
-    if [ "$STATE" = "State=closing" ] ; then
-       loginctl kill-session $s
-    fi
-done
+# For now, kill a blacklist of daemons.
+pkill -f '/usr/bin/kano-tracker-ctl refresh --watch'
+pkill -f '/usr/bin/kano-boards-daemon'
+pkill -f '/usr/bin/kano-mount-trigger'
+pkill -f '/usr/bin/kano-speakerleds cpu-monitor start --check'
 
 return 0


### PR DESCRIPTION
This PR changes the cleanup script to kill a specified list of daemons
@skarbat @tombettany 
For https://github.com/KanoComputing/os-dashboard/issues/108