### PR TITLE
Avoid going to Dashboard on RPi models below 2B

### DIFF
--- a/bin/kano-dashboard-confirm
+++ b/bin/kano-dashboard-confirm
@@ -13,8 +13,8 @@ is_rpi2_or_above=`python -c "from kano.utils.hardware import has_min_performance
   RPI_2_B_SCORE ; print has_min_performance(RPI_2_B_SCORE)"`
 
 if [ "$is_rpi2_or_above" != "True" ]; then
-    kano-dialog title="Dashboard no supported" \
-        description="Please, consider upgrading to a RaspberryPI 2 or above." \
+    kano-dialog title="The Dashboard is not supported on your device" \
+        description="Please upgrade to the Raspberry Pi 2 or above" \
         buttons=Ok:orange:1
 
     exit 1

--- a/bin/kano-dashboard-confirm
+++ b/bin/kano-dashboard-confirm
@@ -7,14 +7,28 @@
 #  It is called from the Dashboard Desktop icon.
 #
 
-kano-dialog title="Dashboard Mode" \
+# If the kit is running on a RaspberryPI model below 2B,
+# do not switch, because the Dashboard is not supported.
+is_rpi2_or_above=`python -c "from kano.utils.hardware import has_min_performance,\
+  RPI_2_B_SCORE ; print has_min_performance(RPI_2_B_SCORE)"`
+
+if [ "$is_rpi2_or_above" != "True" ]; then
+    kano-dialog title="Dashboard no supported" \
+        description="Please, consider upgrading to a RaspberryPI 2 or above." \
+        buttons=Ok:orange:1
+
+    exit 1
+else
+    # We are good to go, ask confirmation and switch to Dashboard
+    kano-dialog title="Dashboard Mode" \
     description="Do you want to return to the Dashboard now?" \
     buttons=Yes:orange:1,Later:orange:2
 
-if [ "$?" == "1" ]; then
-    # Yes, let's do it
-    sudo kano-dashboard-uimode dashboard
-    exit 0
-fi
+    if [ "$?" == "1" ]; then
+        # Yes, let's do it
+        sudo kano-dashboard-uimode dashboard
+        exit 0
+    fi
 
-exit 1
+    exit 1
+fi

--- a/bin/kano-uixinit
+++ b/bin/kano-uixinit
@@ -126,8 +126,12 @@ kano_keyboard=`python -c "from kano.utils import detect_kano_keyboard; print det
 # loads and sets the keyboard layout
 set_keyboard $kano_keyboard
 
-# Jump to Dashboard Mode, unless instructed otherwise
-if [ "${DESKTOP_MODE}" != "1" ]; then
+is_rpi2_or_above=`python -c "from kano.utils.hardware import has_min_performance,\
+RPI_2_B_SCORE ; print has_min_performance(RPI_2_B_SCORE)"`
+
+# By default always go to the Dashboard Mode, except if switching to Desktop Mode,
+# or the Raspberry model is below RPi2B, because Dashboard is not supported.
+if [ "${DESKTOP_MODE}" != "1" ] && [ "$is_rpi2_or_above" == "True" ] ; then
     logger --id --tag "info" "kano-uixinit terminates into Dashboard Supervisor"
     # only run updater once each boot
     [ "$DESKTOP_RUN" -eq 1 ]  &&  sudo kano-updater-quickcheck


### PR DESCRIPTION
 * In such cases, go directly to Desktop mode
 * Having the check on uixinit will work during boot and Greeter login
