### PR TITLE
Watchdog fix

### DIFF
--- a/config/systemd/kano.conf
+++ b/config/systemd/kano.conf
@@ -1,4 +1,0 @@
-# Kano OS specific configuration for systemd
-
-[Manager]
-DefaultTimeoutStopSec=30s

--- a/debian/install
+++ b/debian/install
@@ -19,7 +19,6 @@ config/profile usr/share/kano-desktop/config
 config/rxvt/x11-rxvt etc/X11/Xresources
 config/gtk-2.0 etc/skel/.config/
 config/dconf etc/skel/.config/
-config/systemd/* usr/lib/systemd/system.conf.d
 config/console usr/share/kano-desktop/config
 
 videos usr/share/kano-media

--- a/debian/postinst
+++ b/debian/postinst
@@ -132,6 +132,16 @@ case "$1" in
         # configure console
         cp usr/share/kano-desktop/config/console/console-setup /etc/default/
 
+        # configure systemd
+        # For now, we have to edit system.conf, as v215 doesn't support
+        # system.conf.d yet.
+        
+        systemd_conf='/etc/systemd/system.conf'
+
+        # configure systemd -  remove watchdog error message
+        sed -i "s/#ShutdownWatchdogSec=.*$/ShutdownWatchdogSec=0/g" $systemd_conf
+        # configure systemd - reduce reboot timeout.
+        sed -i "s/#DefaultTimeoutStopSec=.*$/DefaultTimeoutStopSec=30s/g"  $systemd_conf
         ;;
 esac
 


### PR DESCRIPTION
This PR adds  a config option to remove the watchdog error message on reboot.
Unfortunately the version of systemd we are using doesn't support
system.conf.d so we have to edit system.conf in postinst for now. This means our change to the default timeout also weren't working, so I have fixed that as well.

@skarbat @alex5imon 
For https://github.com/KanoComputing/peldins/issues/2345
