### PR TITLE
Remove the Iconize button from all windows.

### DIFF
--- a/config/openbox/rc.xml
+++ b/config/openbox/rc.xml
@@ -44,7 +44,7 @@
 
 <theme>
   <name>Kano</name>
-  <titleLayout>NLIMC</titleLayout>
+  <titleLayout>NLMC</titleLayout>
   <!--
       available characters are NDSLIMC, each can occur at most once.
       N: window icon
@@ -392,7 +392,6 @@
     <mousebind button="Right" action="Press">
       <action name="Focus"/>
       <action name="Raise"/>
-      <action name="ShowMenu"><menu>client-menu</menu></action>
     </mousebind>
   </context>
 
@@ -445,7 +444,6 @@
     <mousebind button="Right" action="Press">
       <action name="Focus"/>
       <action name="Raise"/>
-      <action name="ShowMenu"><menu>client-menu</menu></action>
     </mousebind>
   </context>
 
@@ -511,12 +509,10 @@
       <action name="Focus"/>
       <action name="Raise"/>
       <action name="Unshade"/>
-      <action name="ShowMenu"><menu>client-menu</menu></action>
     </mousebind>
     <mousebind button="Right" action="Press">
       <action name="Focus"/>
       <action name="Raise"/>
-      <action name="ShowMenu"><menu>client-menu</menu></action>
     </mousebind>
   </context>
 


### PR DESCRIPTION
For https://github.com/KanoComputing/kano-overworld/issues/294 @alex5imon 
As discussed, it removed the Iconify button and window-management menus.