### PR TITLE
Fixed tracking during logon / logout

### DIFF
--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -23,9 +23,58 @@
 export NO_AT_BRIDGE=1
 systemctl --user import-environment
 
+function track_startup
+{
+    touch /tmp/ztartup
+
+    # Report a startup event to Kano Tracker
+    kano-tracker-ctl +1 startup
+
+    if [ is_internet ]; then
+        # Try uploading the tracking data to our servers
+        # Should be quiet on failure
+        kano-sync --upload-tracking-data --silent
+
+        # Sync objects from the content API in the background
+        # TODO: This should be removed once we have the daemon done
+        sudo kano-content sync &
+
+        kano-tracker-ctl +1 'internet-connection-established'
+    fi
+}
+
+# Is this the first time we executed this boot?
+test -f /run/lock/desktop_init_run
+DESKTOP_RUN=$?
+touch /run/lock/desktop_init_run
+FIRST_BOOT=1
+
+if [ "$DESKTOP_RUN" -eq 1 ] ; then
+
+   logger --id --tag "info" "kano-uixinit-systemd first execution"
+
+   # Finalise account setup
+   # NB sudo costs us 1 second here, could save it by checking the
+   # json file
+   sudo kano-init finalise || FIRST_BOOT=0
+
+   track_startup
+
+   if [ "$FIRST_BOOT" -eq 1 ] ; then
+       # Finalise account setup
+       logger --id --tag "info" "kano-uixinit first boot"
+       sudo kano-updater first-boot
+   fi
+
+fi
+
 # Are we on a RaspberryPI 2 or above?
 is_rpi2_or_above=`python -c "from kano.utils.hardware import has_min_performance,\
 RPI_2_B_SCORE ; print has_min_performance(RPI_2_B_SCORE)"`
+
+#
+# Dashboard Or Desktop mode ?
+#
 
 # By default always go to the Dashboard Mode, except if switching to Desktop Mode,
 # or the Raspberry model is below RPi2B, because Dashboard is not supported.

--- a/bin/kano-uixinit-systemd
+++ b/bin/kano-uixinit-systemd
@@ -41,52 +41,6 @@ function set_keyboard
     sudo /usr/bin/kano-settings-cli set keyboard --load
 }
 
-function track_startup
-{
-    # Report a startup event to Kano Tracker
-    kano-tracker-ctl +1 startup
-
-    if [ is_internet ]; then
-        # Try uploading the tracking data to our servers
-        # Should be quiet on failure
-        kano-sync --upload-tracking-data --silent
-
-        # Sync objects from the content API in the background
-        # TODO: This should be removed once we have the daemon done
-        sudo kano-content sync &
-
-        kano-tracker-ctl +1 'internet-connection-established'
-    fi
-}
-
-############ STARTS HERE ############
-
-# Is this the first time we executed this boot?
-
-test -f /run/lock/desktop_init_run
-DESKTOP_RUN=$?
-touch /run/lock/desktop_init_run
-FIRST_BOOT=1
-
-if [ "$DESKTOP_RUN" -eq 1 ] ; then
-
-   logger --id --tag "info" "kano-uixinit-systemd first execution"
-
-   # Finalise account setup
-   # NB sudo costs us 1 second here, could save it by checking the
-   # json file
-   sudo kano-init finalise || FIRST_BOOT=0
-
-   track_startup
-
-   if [ "$FIRST_BOOT" -eq 1 ] ; then
-       # Finalise account setup
-       logger --id --tag "info" "kano-uixinit first boot"
-       sudo kano-updater first-boot
-   fi
-
-fi
-
 # Track some information about the hardware used
 kano-tracker-ctl generate hw-info
 

--- a/scripts/ldm-session-cleanup-script
+++ b/scripts/ldm-session-cleanup-script
@@ -16,14 +16,7 @@ su - $USER -c "kano-tracker-ctl clear"
 su - $USER -c "kano-tracker-ctl new-token"
 su - $USER -c "kano-sync --upload-tracking-data --silent"
 
-
-# kill old session: kills any processes still running from
-# the old session.
-
-# For now, kill a blacklist of daemons.
-pkill -f '/usr/bin/kano-tracker-ctl refresh --watch'
-pkill -f '/usr/bin/kano-boards-daemon'
-pkill -f '/usr/bin/kano-mount-trigger'
-pkill -f '/usr/bin/kano-speakerleds cpu-monitor start --check'
+# All user apps and keep-alive processes
+# are killed automatically by systemd, nothing to do here.
 
 return 0


### PR DESCRIPTION
 * The startup tracking event was only happening when going to the Desktop
 * Fixed by moving it to Lightdm autostart. It will run after a Greeter login,
   on a multiuser kit, and during bootup.
 * Removed useless kill commands, which have now migrated to systemd

cc @Ealdwulf 