### PR TITLE
Kano hotkeys in Dashboard and Desktop

### DIFF
--- a/bin/kano-keyboard-hotkeys
+++ b/bin/kano-keyboard-hotkeys
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# kano-keyboard-hotkeys
+#
+# Listens for Kano Keyboard FN keys using xbindkeys daemon, and sets up layout.
+# Supports regular keyboards as well through custom profiles.
+#
+# This script is registered as a systemd unit, to work on Dashboard and Desktop.
+#
+
+function set_keyboard
+{
+    # Load Kano Keyboard configuration file for Hotkeys, or a generic one for regular keyboards
+    keyboard_conf_dir="/usr/share/kano-desktop/config/keyboard"
+    if [ "$1" = "True" ]; then
+        keyboard_conf="$keyboard_conf_dir/kanokeyboardrc"
+    else
+        keyboard_conf="$keyboard_conf_dir/generickeyboardrc"
+    fi
+
+    echo "setting keyboard $keyboard_conf" >> $logfile
+    logger --id --tag "info" "Launching xbindkeys with configuration: $keyboard_conf"
+    /usr/bin/xbindkeys -f $keyboard_conf
+
+    # Set user keyboard layout
+    logger --id --tag "info" "Setting the keyboard layout for the user"
+    sudo /usr/bin/kano-settings-cli set keyboard --load
+}
+
+# detect kano-keyboard
+kano_keyboard=`python -c "from kano.utils import detect_kano_keyboard; print detect_kano_keyboard()"`
+
+# loads and sets the keyboard layout
+set_keyboard $kano_keyboard
+
+exit 0

--- a/bin/kano-uixinit-systemd
+++ b/bin/kano-uixinit-systemd
@@ -24,23 +24,6 @@ logger --id --tag "info" "uixinit systemd starts"
 # FIXME: is this still needed?
 mkdir -p "$HOME/.kano-settings"
 
-function set_keyboard
-{
-    # Load Kano Keyboard configuration file for Hotkeys, or a generic one for regular keyboards
-    keyboard_conf_dir="/usr/share/kano-desktop/config/keyboard"
-    if [ "$1" = "True" ]; then
-        keyboard_conf="$keyboard_conf_dir/kanokeyboardrc"
-    else
-        keyboard_conf="$keyboard_conf_dir/generickeyboardrc"
-    fi
-    logger --id --tag "info" "Launching xbindkeys with configuration: $keyboard_conf"
-    /usr/bin/xbindkeys -f $keyboard_conf
-
-    # Set user keyboard layout
-    logger --id --tag "info" "Setting the keyboard layout for the user"
-    sudo /usr/bin/kano-settings-cli set keyboard --load
-}
-
 # Track some information about the hardware used
 kano-tracker-ctl generate hw-info
 
@@ -50,12 +33,6 @@ if [ -n "`which xset`" ]; then
     xset -dpms
     xset s noblank
 fi
-
-# detect kano-keyboard
-kano_keyboard=`python -c "from kano.utils import detect_kano_keyboard; print detect_kano_keyboard()"`
-
-# loads and sets the keyboard layout
-set_keyboard $kano_keyboard
 
 # Calibrates the mouse pointer speed
 /usr/bin/startmouse

--- a/debian/install
+++ b/debian/install
@@ -31,6 +31,7 @@ bin/open-me etc/skel/.Rabbithole
 bin/use-the-force usr/bin
 bin/kano-dashboard-confirm usr/bin
 bin/make-adventures usr/bin
+bin/kano-keyboard-hotkeys usr/bin
 
 scripts/* usr/share/kano-desktop/scripts
 

--- a/systemd/kano-common-keyboard.service
+++ b/systemd/kano-common-keyboard.service
@@ -1,0 +1,11 @@
+#
+# kano-common-keyboard
+#
+
+[Unit]
+Description=Kano Keyboard Hotkeys
+IgnoreOnIsolate=true
+
+[Service]
+ExecStart=/usr/bin/kano-keyboard-hotkeys
+Type=forking

--- a/systemd/kano-common.target
+++ b/systemd/kano-common.target
@@ -8,4 +8,5 @@
 Description=Kano Common User Services
 IgnoreOnIsolate=true
 Requires=kano-common-tracker.service kano-common-notifications.service \
- kano-common-speakerleds.service kano-common-boards.service
+ kano-common-speakerleds.service kano-common-boards.service \
+ kano-common-keyboard.service


### PR DESCRIPTION
This should fix the hotkeys on the Kano Keyboard which were not working after the systemd migration.

Links to ticket: https://github.com/KanoComputing/peldins/issues/2368

cc @tombettany @alex5imon 
