### PR TITLE
Fix potential issue if SDL apps started from ssh or lxterminal

### DIFF
--- a/config/profile/kano-bashrc
+++ b/config/profile/kano-bashrc
@@ -55,6 +55,11 @@ if [ `pidof lxsession` ]; then
     export $(cat /proc/$(pidof lxsession)/environ |xargs -0 echo )
 fi
 
+# The default systemd environment will export the X11 bindings for graphic apps.
+# Force SDL to discard this option and use the RPi dispmanX driver instead.
+# Fixes problem if user wants to start SDL apps from ssh or lxterminal.
+export SDL_VIDEODRIVER="rpi"
+
 # Enforce umask so that user files
 # cannot be seen/touched by others
 umask 022


### PR DESCRIPTION
 * By default SDL will try to connect to the Xserver which is no supported
 * The fix will tell SDL to always attach to the RPi Dispmanx graphics driver

cc @radujipa @tombettany @Ealdwulf 
