### PR TITLE
Fixes DESKTOP_MODE environment not set correctly

### DIFF
--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -74,9 +74,10 @@ RPI_2_B_SCORE ; print has_min_performance(RPI_2_B_SCORE)"`
 # Dashboard Or Desktop mode ?
 #
 
-# By default always go to the Dashboard Mode, except if switching to Desktop Mode,
-# or the Raspberry model is below RPi2B, because Dashboard is not supported.
-if [ "${DESKTOP_MODE}" != "1" ] && [ "$is_rpi2_or_above" == "True" ] ; then
+# By default always go to the Dashboard when Lightdm starts (bootup, greeter login)
+# Except on Raspberry models below RPi2B, because Dashboard is not supported.
+# Switching between both modes goes through systemd units (no lightdm restart).
+if [ "$is_rpi2_or_above" == "True" ] ; then
     logger --id --tag "info" "Starting systemd Dashboard mode"
     systemctl --user start kano-dashboard.service
 else

--- a/systemd/kano-desktop-lxpanel.service
+++ b/systemd/kano-desktop-lxpanel.service
@@ -15,6 +15,7 @@ BindsTo=kano-desktop.service
 
 [Service]
 ExecStart=/usr/bin/lxpanel --profile LXDE
+Environment="DESKTOP_MODE=1"
 
 [Install]
 WantedBy=kano-desktop.service


### PR DESCRIPTION
 * The reason being we were still using the .xsessionrc
 * Fixed by moving into the systemd unit file for lxsession
 * Removed unnecessary check for Desktop Mode in lightdm autostart

cc @tombettany @Ealdwulf 
