### PR TITLE
Preserve DESKTOP_MODE environment

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -21,7 +21,11 @@ custom_lxde_autostart=/usr/share/kano-desktop/config/autostart/autostart
 
 SQUEAKDIR=/usr/share/squeak
 
+# Additional sudo commands
 TMP_SUDOERS_FILE=/tmp/kano-desktop_conf
+
+# Preserve sudo environment
+TMP_SUDO_ENVIRON_FILE=/tmp/kano-environment_conf
 
 ldm_conf=/etc/lightdm/lightdm.conf
 ldm_login=/usr/share/kano-desktop/scripts/ldm-session-setup-script
@@ -110,6 +114,12 @@ case "$1" in
 
         # Move the file to the sudoers directory
         mv $TMP_SUDOERS_FILE /etc/sudoers.d/
+
+        # Populate the DESKTOP_MODE environment to all sudoed applications
+        echo "Defaults env_keep += \"DESKTOP_MODE\"" > $TMP_SUDO_ENVIRON_FILE
+        chown root:root $TMP_SUDO_ENVIRON_FILE
+        chmod 0440 $TMP_SUDO_ENVIRON_FILE
+        mv $TMP_SUDO_ENVIRON_FILE /etc/sudoers.d/
 
         # Add login and logoff hooks to track usage of the kit
         sed -i "s|#\?\(session-setup-script\=\).*|\1$ldm_login|" $ldm_conf


### PR DESCRIPTION
 * for all applications sudoed in desktop mode, make the environment var available
 * the environment variable comes from the desktop mode systemd unit file

@tombettany 