### PR TITLE
Sudo scratch

### DIFF
--- a/bin/kano-scratch-launch
+++ b/bin/kano-scratch-launch
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# kano-scratch-launch
+#
+# Copyright (C) 2016 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# For the time being launch scratch using sudo
+
+export WRAPPER=sudo 
+/usr/bin/scratch
+

--- a/debian/install
+++ b/debian/install
@@ -34,6 +34,7 @@ bin/use-the-force usr/bin
 bin/kano-dashboard-confirm usr/bin
 bin/make-adventures usr/bin
 bin/kano-keyboard-hotkeys usr/bin
+bin/kano-scratch-launch /usr/bin
 
 scripts/* usr/share/kano-desktop/scripts
 

--- a/debian/install
+++ b/debian/install
@@ -21,7 +21,7 @@ config/gtk-2.0 etc/skel/.config/
 config/dconf etc/skel/.config/
 config/console usr/share/kano-desktop/config
 
-config/sudoers.d/* /etc/sudoers.d
+config/sudoers.d/* usr/share/kano-desktop/config/sudoers.d
 
 videos usr/share/kano-media
 gtk-themes/Kano usr/share/themes

--- a/debian/postinst
+++ b/debian/postinst
@@ -94,6 +94,9 @@ case "$1" in
         cp $lxde_autostart $lxde_autostart-old
         cp $custom_lxde_autostart $lxde_autostart
 
+        # Copy the sudoers files
+        cp /usr/share/kano-desktop/config/sudoers.d/* /etc/sudoers.d/
+
         # Enforce permissions to our sudoers files
         chmod 0440 $SUDOERS_DIR/kano-desktop_conf
         chmod 0440 $SUDOERS_DIR/kano-environment_conf

--- a/kdesk/kdesktop/Scratch.lnk
+++ b/kdesk/kdesktop/Scratch.lnk
@@ -1,7 +1,7 @@
 table Icon
   Caption:
   AppID: Scratch
-  Command: kano-tracker-ctl session run scratch /usr/bin/scratch
+  Command: kano-tracker-ctl session run scratch /usr/bin/kano-scratch-launch
   Singleton: true
   Icon: /usr/share/kano-desktop/icons/scratch.png
   IconHover: /usr/share/kano-desktop/icons/scratch-hover.png


### PR DESCRIPTION
This PR makes scratch run with sudo @alex5imon
I had also to fix the postinst to manually copy the sudoers file, as dpkg didn't install it for me @tombettany @skarbat. This is a problem I've run into before: if something deletes a file in `/etc`, dpkg assumes that the user has deleted it and won't automatically install a new one as it's a 'config file'. And we delete it in the postrm, which has the same effect. So it must be manually copied. 
