### PR TITLE
Fixing widgets not killed when going to Dashboard

### DIFF
--- a/config/sudoers.d/kano-desktop_conf
+++ b/config/sudoers.d/kano-desktop_conf
@@ -1,4 +1,13 @@
 
+# Adding restricted command aliases to kill widgets that have been sudoed from LXPanel taskbar
+# The reason behind this is that systemd cannot kill them if sudoed this way for some reason
+# The alias allows us to limit the scope of a password-less pkill run as the superuser.
+# Look at kano-desktop-lxpanel systemd unit to see usage of these aliases.
+#
+Cmnd_Alias KILL_DESKTOP_WIDGETS = /usr/bin/pkill -f kano-settings, /usr/bin/pkill -f kano-wifi-gui
+
+%sudo   ALL=(root) NOPASSWD: KILL_DESKTOP_WIDGETS
+
 # allow user to switch to virtual console terminals
 %sudo   ALL=(root) NOPASSWD: /bin/chvt
 

--- a/systemd/kano-desktop-lxpanel.service
+++ b/systemd/kano-desktop-lxpanel.service
@@ -6,7 +6,9 @@
 # The "BindsTo" clause makes a behaviour dependency with the main service.
 # It is started and stopped along with the Desktop unit.
 #
-# FIXME: For now it's still under early testing
+# The ExecStop statement kills sudoed widgets started from the taskbar,
+# which systemd cannot kill himself, even if they belong to the same cgroup namespace.
+# See kano-desktop sudoers definition for details.
 #
 
 [Unit]
@@ -16,6 +18,7 @@ BindsTo=kano-desktop.service
 [Service]
 ExecStart=/usr/bin/lxpanel --profile LXDE
 Environment="DESKTOP_MODE=1"
+ExecStop=/usr/bin/sudo /usr/bin/pkill -f kano-settings ; /usr/bin/sudo /usr/bin/pkill -f kano-wifi-gui
 
 [Install]
 WantedBy=kano-desktop.service


### PR DESCRIPTION
 * Sudoed widgets started from the taskbar cannot be killed by systemd
 * Added kill statements for settings and wireless widgets in the systemd unit
 * Added restricted sudo aliases to allow these kill commands to proceed blindly
 * Confirmed that kano-updater keeps running in the background in such cases

Resolves this issue: https://github.com/KanoComputing/os-dashboard/issues/178

cc @Ealdwulf @radujipa 
