### PR TITLE
Fixing scratch not closing on Dashboard switch

### DIFF
--- a/config/sudoers.d/kano-desktop_conf
+++ b/config/sudoers.d/kano-desktop_conf
@@ -4,7 +4,10 @@
 # The alias allows us to limit the scope of a password-less pkill run as the superuser.
 # Look at kano-desktop-lxpanel systemd unit to see usage of these aliases.
 #
-Cmnd_Alias KILL_DESKTOP_WIDGETS = /usr/bin/pkill -f kano-settings, /usr/bin/pkill -f kano-wifi-gui
+# Scratch is sudoed from kdesk and suffers from a similar issue.
+#
+Cmnd_Alias KILL_DESKTOP_WIDGETS = /usr/bin/pkill -f kano-settings, \
+  /usr/bin/pkill -f kano-wifi-gui, /usr/bin/pkill -f scratch
 
 %sudo   ALL=(root) NOPASSWD: KILL_DESKTOP_WIDGETS
 

--- a/systemd/kano-desktop.service
+++ b/systemd/kano-desktop.service
@@ -6,7 +6,8 @@
 # The "Requires" clause makes a the lxpanel start along with it,
 # which allows for grouping several services from this one.
 #
-# FIXME: For now it's still under early testing (starts kdesk only with hourglass)
+# Forcibly closing scratch on termination, because it is sudoed
+# and is misteriously started outside systemd cgroup.
 #
 
 [Unit]
@@ -18,3 +19,4 @@ Conflicts=kano-dashboard.service
 [Service]
 ExecStartPre=/usr/bin/kdesk-hourglass-app "lxpanel"
 ExecStart=/usr/bin/kdesk
+ExecStop=/usr/bin/sudo /usr/bin/pkill -f scratch


### PR DESCRIPTION
 * Scratch is sudoed from kdesk icon, and it does not show on systemd process tree
 * Fixing by forcibly killing it on termination of the systemd unit

@Ealdwulf 
