### PR TITLE
Replaced typewriter to avoid auto overscan from kano-init

### DIFF
--- a/bin/open-me
+++ b/bin/open-me
@@ -11,7 +11,8 @@
 import os
 import sys
 import time
-from kano_init.terminal import typewriter_echo, clear_screen
+import subprocess
+
 from kano_init.ascii_art.rabbit import rabbit
 from kano_init.ascii_art.matrix import matrix
 from kano.utils import get_user_unsudoed
@@ -26,16 +27,16 @@ if __name__ == '__main__' and __package__ is None:
 def main():
     # Play matrix animation
     matrix(2, False)
-    clear_screen()
+    subprocess.call(['clear'])
     # Show text
     msg = "Nicely done {}, you found me!".format(get_user_unsudoed())
-    typewriter_echo(msg, trailing_linebreaks=2)
+    subprocess.call(['typewriter_echo', msg, '0', '3'])
     time.sleep(2)
     # Play rabbit animation
     rabbit(1, 'left-to-right')
     # Unlock the easter egg badge
     increment_app_state_variable_with_dialog('easter_egg', 'starts', 1)
-    clear_screen()
+    subprocess.call(['clear'])
 
 if __name__ == '__main__':
     main()

--- a/bin/use-the-force
+++ b/bin/use-the-force
@@ -9,6 +9,8 @@
 
 import os
 import sys
+import subprocess
+
 from kano.utils import get_user_unsudoed
 from kano.network import is_internet
 from kano.logging import logger
@@ -38,5 +40,5 @@ if __name__ == '__main__':
         logger.info('use-the-force executed with no internet')
         # Show text
         msg = "\n\nInternet you must have my young padawan {}.".format(get_user_unsudoed())
-        typewriter_echo(msg, trailing_linebreaks=2)
+        subprocess.call(['typewriter_echo', msg, '0', '3'])
         sys.exit(1)


### PR DESCRIPTION
Related to https://github.com/KanoComputing/peldins/issues/2382

The issue is due to `kano_init.terminal` sets the overscan [here](https://github.com/KanoComputing/kano-init/blob/jessie/kano_init/terminal.py#L67) automatically... Given that kano-init relies on this to sometimes set it and sometimes not in different stages, I'm going to avoid fixing the issue there. In this PR I've replaced the typewriter with the bash version from `kano-toolset/bin`.

cc @Ealdwulf @tombettany 