### PR TITLE
Fix sentry

### DIFF
--- a/config/sudoers.d/kano-desktop_conf
+++ b/config/sudoers.d/kano-desktop_conf
@@ -6,8 +6,8 @@
 #
 # Scratch is sudoed from kdesk and suffers from a similar issue.
 #
-Cmnd_Alias KILL_DESKTOP_WIDGETS = /usr/bin/pkill -f kano-settings, \
-  /usr/bin/pkill -f kano-wifi-gui
+Cmnd_Alias KILL_DESKTOP_WIDGETS = /usr/bin/pkill kano-settings, \
+  /usr/bin/pkill kano-wifi-gui
 
 %sudo   ALL=(root) NOPASSWD: KILL_DESKTOP_WIDGETS
 

--- a/systemd/kano-desktop-lxpanel.service
+++ b/systemd/kano-desktop-lxpanel.service
@@ -18,7 +18,7 @@ BindsTo=kano-desktop.service
 [Service]
 ExecStart=/usr/bin/lxpanel --profile LXDE
 Environment="DESKTOP_MODE=1"
-ExecStop=/usr/bin/sudo /usr/bin/pkill -f kano-settings ; /usr/bin/sudo /usr/bin/pkill -f kano-wifi-gui
+ExecStop=/usr/bin/sudo /usr/bin/pkill kano-settings ; /usr/bin/sudo /usr/bin/pkill kano-wifi-gui
 
 [Install]
 WantedBy=kano-desktop.service


### PR DESCRIPTION
This PR prevents the kano-desktop systemd script from killing sentry (and all internet access in parental control mode).
It removes -f argument from pkill. This was too broad - it was catching sentry which only has 'kano-settings' in its arguments. Have tested that it still kills kano-settings.

Points to why   https://github.com/KanoComputing/os-dashboard/issues/202 is a good idea in the long run.

@skarbat @alex5imon
