### PR TITLE
Replacing notifications daemon with new QML based version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-desktop (3.2.2-1) unstable; urgency=low
+
+  * Migrated system notifications daemon to QML version
+
+ -- Team Kano <dev@kano.me>  Wed, 6 Jul 2016 14:39:10 +0100
+
 kano-desktop (3.2.1-1) unstable; urgency=low
 
   * Migrated Dashboard and Computer modes to systemd

--- a/systemd/kano-common-notifications.service
+++ b/systemd/kano-common-notifications.service
@@ -1,6 +1,7 @@
 #
 # kano-common-notifications
 #
+# Daemon to provide system wide notifications using QML
 #
 
 [Unit]
@@ -8,4 +9,4 @@ Description=Kano user notifications daemon
 IgnoreOnIsolate=true
 
 [Service]
-ExecStart=/usr/bin/kano-notifications-daemon
+ExecStart=/usr/bin/kano-notifications -d -v

--- a/systemd/kano-common-notifications.service
+++ b/systemd/kano-common-notifications.service
@@ -3,6 +3,9 @@
 #
 # Daemon to provide system wide notifications using QML
 #
+# FIXME: This service deprecates /usr/bin/kano-notifications-daemon
+# which is still contained in the kano-widgets package.
+#
 
 [Unit]
 Description=Kano user notifications daemon

--- a/systemd/kano-common-notifications.service
+++ b/systemd/kano-common-notifications.service
@@ -10,3 +10,5 @@ IgnoreOnIsolate=true
 
 [Service]
 ExecStart=/usr/bin/kano-notifications -d -v
+Type=forking
+StandardOutput=syslog

--- a/systemd/kano-common-notifications.service
+++ b/systemd/kano-common-notifications.service
@@ -9,6 +9,6 @@ Description=Kano user notifications daemon
 IgnoreOnIsolate=true
 
 [Service]
-ExecStart=/usr/bin/kano-notifications -d -v
+ExecStart=/usr/bin/kano-notifications -d -v --sound=file:////usr/share/kano-media/sounds/kano_open_app.wav --timeout=3000
 Type=forking
 StandardOutput=syslog


### PR DESCRIPTION
This changeset depends on: https://github.com/KanoComputing/os-dashboard/pull/212
