### PR TITLE
Forcing kdesk to run screen saver at a higer graphics layer

### DIFF
--- a/systemd/kano-desktop.service
+++ b/systemd/kano-desktop.service
@@ -19,3 +19,4 @@ Conflicts=kano-dashboard.service
 [Service]
 ExecStartPre=/usr/bin/kdesk-hourglass-app "lxpanel"
 ExecStart=/usr/bin/kdesk
+Environment="KDESK_EGLSAVER_LAYER=5"


### PR DESCRIPTION
 * Hides notifications while screen saver is running

@tombettany 
