### PR TITLE
Make sure notifications daemon is always alive

### DIFF
--- a/systemd/kano-common-notifications.service
+++ b/systemd/kano-common-notifications.service
@@ -15,3 +15,5 @@ IgnoreOnIsolate=true
 ExecStart=/usr/bin/kano-notifications -d -v --sound=file:////usr/share/kano-media/sounds/kano_achievement_unlock.wav --timeout=3000
 Type=forking
 StandardOutput=syslog
+RestartSec=1
+Restart=always


### PR DESCRIPTION
 * Should the daemon terminate by any reason, systemd should restart it
 * Specially important because the notifications pipe would potentially block writers

@Ealdwulf @tombettany 