### PR TITLE
Fixed easter egg from setting unintentional overscan

### DIFF
--- a/bin/use-the-force
+++ b/bin/use-the-force
@@ -15,7 +15,6 @@ from kano.utils import get_user_unsudoed
 from kano.network import is_internet
 from kano.logging import logger
 from kano_profile.badges import increment_app_state_variable_with_dialog
-from kano_init.terminal import typewriter_echo
 
 
 if __name__ == '__main__' and __package__ is None:


### PR DESCRIPTION
Related to https://trello.com/c/eHksitNY/129-use-the-force-does-this

Complements this old fix here .. https://github.com/KanoComputing/kano-desktop/pull/186/files#diff-ba06a1ea91f4be4927f8905d4f5a1068L16

@Ealdwulf @skarbat this alright?