### PR TITLE
Add rpi-chromium-mods package.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,8 @@ Depends: ${misc:Depends}, openbox (>=3.5.2-4~kano.1),
          kano-video-files (>=1.1-2), kano-init-flow (>=2.2-1), kano-profile (>=2.2.0-4),
          libkdesk-dev, kano-greeter, kano-updater (>=3.0.0-1),
          kano-apps (>=2.0-1), kano-settings (>=2.0-1), kano-content, telnet,
-         kano-widgets (>=2.2-1), kano-applets, chromium-browser (>= 41.0), kano-dashboard(>=0.1)
+         kano-widgets (>=2.2-1), kano-applets, chromium-browser (>= 41.0), kano-dashboard(>=0.1),
+         rpi-chromium-mods
 Replaces: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Breaks: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Description: The desktop experience of Kanux


### PR DESCRIPTION
This PR adds the rpi-chromium-mods package which the RPI foundation use to set chromium to use only h264.
This doesn't yet appear to be sufficient to get hardware decoding to work, but it's necessary.
@skarbat @radujipa 