### PR TITLE
Don't set chromium master prefs (will be installed by rpi-chromium-mods)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Depends: ${misc:Depends}, openbox (>=3.5.2-4~kano.1),
          libkdesk-dev, kano-greeter, kano-updater (>=3.0.0-1),
          kano-apps (>=2.0-1), kano-settings (>=2.0-1), kano-content, telnet,
          kano-widgets (>=2.2-1), kano-applets, chromium-browser (>= 41.0), kano-dashboard(>=0.1),
-         rpi-chromium-mods
+         rpi-chromium-mods-kano
 Replaces: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Breaks: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Description: The desktop experience of Kanux

--- a/debian/postinst
+++ b/debian/postinst
@@ -10,8 +10,7 @@ openbox_rc=/etc/xdg/openbox/rc.xml
 lxde_openbox_rc=/etc/xdg/openbox/LXDE/rc.xml
 custom_openbox_rc=/usr/share/kano-desktop/openbox/rc.xml
 
-chromium_master_prefs=/usr/lib/chromium-browser/master_preferences
-custom_chromium_master_prefs=/usr/share/kano-desktop/config/chromium/master_preferences
+# NB, chromium master_preferences is now installed by our fork of rpi-chromium-mods
 
 chromium_bookmarks=/usr/lib/chromium-browser/initial_bookmarks.html
 custom_chromium_bookmarks=/usr/share/kano-desktop/config/chromium/initial_bookmarks.html
@@ -73,14 +72,6 @@ case "$1" in
 
         cp $lxde_openbox_rc $lxde_openbox_rc-old
         cat $custom_openbox_rc > $lxde_openbox_rc
-
-        # Do a safeguard copy of Chromium master preferences
-        if [ -f "$chromium_master_prefs" ]; then
-            cp $chromium_master_prefs $chromium_master_prefs-old
-        fi
-
-        # Set our own  preferences file
-        cat $custom_chromium_master_prefs > $chromium_master_prefs
 
         # Do a safeguard copy of the Chromium bookmarks
         if [ -f "$chromium_bookmarks" ]; then


### PR DESCRIPTION
This PR removes the functionality of setting the chromium master prefs from kano-destop, to a fork of rpi-chromium-mods (which we now depend on)
For https://trello.com/c/QuauOwHJ
There will be another PR to make our changes to rpi-chromium-mods.
@tombettany @radujipa 