### PR TITLE
Remove verbose flag

### DIFF
--- a/systemd/kano-common-notifications.service
+++ b/systemd/kano-common-notifications.service
@@ -12,7 +12,7 @@ Description=Kano user notifications daemon
 IgnoreOnIsolate=true
 
 [Service]
-ExecStart=/usr/bin/kano-notifications -d -v --sound=file:////usr/share/kano-media/sounds/kano_achievement_unlock.wav --timeout=3000
+ExecStart=/usr/bin/kano-notifications -d --sound=file:////usr/share/kano-media/sounds/kano_achievement_unlock.wav --timeout=3000
 Type=forking
 StandardOutput=syslog
 RestartSec=1


### PR DESCRIPTION
Just noticed that there are a flood of syslogs from the notification daemon, because it's started in verbose mode.
@skarbat 