### PR TITLE
Add a dependency on chromium. 

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Depends: ${misc:Depends}, openbox (>=3.5.2-4~kano.1),
          libkdesk-dev, kano-greeter, kano-updater (>=3.0.0-1), kano-home-button,
          kano-apps (>=2.0-1), kano-settings (>=2.0-1), kano-content, telnet,
          kano-widgets (>=2.2-1), kano-applets, chromium-browser (>= 41.0), kano-dashboard(>=0.1),
-         rpi-chromium-mods-kano
+         rpi-chromium-mods-kano, chromium
 Replaces: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Breaks: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Description: The desktop experience of Kanux


### PR DESCRIPTION
Add back the `chromium` backwards-compatability package which provides the symlink.
It isn't being installed because we updated all the app-store packages to use chromium-browser,  but as @tombettany points out, we can't remove it because old installs via the app store would stop working on update.
@skarbat 
