### PR TITLE
Kano K Hotkey triggers a Home button click

### DIFF
--- a/bin/kano-keyboard-hotkeys
+++ b/bin/kano-keyboard-hotkeys
@@ -21,7 +21,7 @@ function set_keyboard
         keyboard_conf="$keyboard_conf_dir/generickeyboardrc"
     fi
 
-    echo "setting keyboard $keyboard_conf" >> $logfile
+    echo "setting keyboard $keyboard_conf"
     logger --id --tag "info" "Launching xbindkeys with configuration: $keyboard_conf"
     /usr/bin/xbindkeys -f $keyboard_conf
 

--- a/config/keyboard/kanokeyboardrc
+++ b/config/keyboard/kanokeyboardrc
@@ -44,8 +44,9 @@
 #keystate_capslock = enable
 #keystate_scrolllock= enable
 
-# FN + K : minimize all windows (Web Home)
-"wmctrl -k on"
+# FN + K : Return to Dashboard (Home button)
+# Note that we assume we run on a RPI >= 2B that supports Dashboard (yes)
+"/usr/share/kano-home-button/hooks/hook-script.sh home_button_clicked 0 0 yes"
   m:0x10 + c:180
   Mod2 + XF86HomePage
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-desktop (3.3.3-1) unstable; urgency=low
+
+  * Added Kano K Hotkey, it clicks on the Home Button
+
+ -- Team Kano <dev@kano.me>  Mon, 9 Jan 2017 16:04:12 +0100
+
 kano-desktop (3.3.2-1) unstable; urgency=low
 
   * Added Kano OS Home Button feature


### PR DESCRIPTION
This changeset replaces the K hotkey functionality.
Instead of minimizing all the apps, it takes the user back to the Dashboard.
Works from Desktop Mode, and Dashboard started apps. Silent in other cases.

@tombettany seems to work fine on all applicable UI modes
