### PR TITLE
Fix for some apps not displaying i18n messages correctly

### DIFF
--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -26,6 +26,9 @@ export NO_AT_BRIDGE=1
 export XKB_DEFAULT_RULES=evdev
 export XKB_DEFAULT_LAYOUT=`setxkbmap -query | grep layout | awk '{print $2}'`
 
+# Tell python modules to use UTF-8 on the console for i18n messages to display accurately.
+export PYTHONIOENCODING=UTF-8
+
 systemctl --user import-environment
 
 function track_startup


### PR DESCRIPTION
This change fixes terminal quest messages eventually displaying garbage for non-ascii translated messages
