### PR TITLE
Fix for eventually losing ssh host keys

### DIFF
--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -118,10 +118,12 @@ kill %?xrefresh
 # TODO: move me to a systemd unit service
 if [ "$FIRST_LOGIN" -eq 1 ]; then
 
-    # regenerating ssh keys
-    logger --id --tag "info" "kano-ui-autostart regenerating ssh host keys"
-    if [ `getent group kanousers | wc -l` -eq 1 ]; then
-        sudo regenerate-ssh-keys &
+    # regenerating ssh keys only if we find one kano user.
+    # we want to have one unique set of host ssh keys per kano kit.
+    # getent format: kanousers:x:1000:user1,user2,user3
+    if [ `getent group kanousers | awk '{lng=split($0, array, ",")} END{print lng }'` -eq 1 ]; then
+	logger --id --tag "info" "kano-ui-autostart regenerating ssh host keys"
+	sudo regenerate-ssh-keys &
     fi
 fi
 


### PR DESCRIPTION
There was a bug in the condition which regenerated the host keys each time a new user was created, eventually failing and losing the keys and consequently ssh server was down.

Fixed the condition to regenerate host keys only when 1 kano user is found after the init flow, in fact we need just one set of ssh keys per kit.

@tombettany @radujipa 
