### PR TITLE
Support for a USB microphone dongle

### DIFF
--- a/config/alsa/.asoundrc
+++ b/config/alsa/.asoundrc
@@ -1,19 +1,32 @@
 pcm.master {
-       	type softvol
-       	slave {
-          	pcm "hw:0"
-        }
-     	control {
-               	name "Master"
-              	card 0
-		count 1
-        }
-     	min_dB -26.0
-     	max_dB 4.0
-     	resolution 8
+    type softvol
+    min_dB -26.0
+    max_dB 4.0
+    resolution 8
+
+    slave {
+        pcm "hw:0"
+    }
+    control {
+        name "Master"
+        card 0
+        count 1
+    }
+}
+
+pcm.usb_mic {
+    type hw
+    card 1
 }
 
 pcm.!default {
-	type plug
-  	slave.pcm "master"
+    type asym
+    playback.pcm {
+        type plug
+        slave.pcm "master"
+    }
+    capture.pcm {
+        type plug
+        slave.pcm "usb_mic"
+    }
 }


### PR DESCRIPTION
The USB microphone I worked with seemed to be recognised as C-Media
CM108. The setup before defined a master channel for controlling
the volume in steps. Here I've defined the capture channel on the
sound card to come by default from a hardware "sound card" with
index 1, which will be the USB mic. There is a chance this will
create problems due to the index when plugging in other audio
devices.

NOTE: I've tested this using Chromium. Previously, with the Settings > Privacy > Content Settings > Microphone > Default, Kano Code wouldn't get any mic input. With this, it now has mic in by default.

@tombettany @skarbat @rluz 