### PR TITLE
Make common systemd services recoverable

### DIFF
--- a/systemd/kano-common.target
+++ b/systemd/kano-common.target
@@ -3,10 +3,14 @@
 #
 # Common keep-alive services until logoff or shutdown
 #
+# Note that "Wanted" is a softer version of "Requires".
+# This unit will try to bring up all dependent services,
+# regardless if any should fail to start.
+#
 
 [Unit]
 Description=Kano Common User Services
 IgnoreOnIsolate=true
-Requires=kano-common-tracker.service kano-common-notifications.service \
+Wants=kano-common-tracker.service kano-common-notifications.service \
  kano-common-speakerleds.service kano-common-boards.service \
  kano-common-keyboard.service kano-home-button.service


### PR DESCRIPTION
kano common services is an umbrella to start needed user services.
If any of the dependent services failed to start, the whole unit would go down.
This changeset fixes the issue by establishing them as a soft dependency.

@radujipa @tombettany 

