### PR TITLE
Get the boards daemon ready for Overture

### DIFF
--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -75,6 +75,9 @@ systemctl --user start kano-home-button
 initflow=`sudo kano-init status`
 if [ "$initflow" != "disabled" ]; then
 
+    # Start the boards daemon so we can talk to hardware periherals during Overture
+    systemctl --user start kano-boards
+
     # Nothing more to do now, empty desktop behind the overture app
     exit 0
 fi


### PR DESCRIPTION
The Overture apps needs this service in order to detect and communicate with the hardware.
This also fixes audio going to HDMI