### PR TITLE
Hide Loading dialog when falling back to Desktop Mode

### DIFF
--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -194,6 +194,7 @@ if [ "$is_rpi2_or_above" == "True" ] ; then
     systemctl --user start kano-dashboard.service
 else
     logger --id --tag "info" "kano-ui-autostart Starting systemd Desktop mode"
+    kano-home-button-visible hide_dialog
     systemctl --user start kano-desktop.service
 fi
 


### PR DESCRIPTION
This changeset fixes an issue where the Loading dialog remains open if falling back to Desktop Mode, due to Dashboard not supported on current RaspberryPI model.

@tombettany 