### PR TITLE
Add missing script to enable Power Button

### DIFF
--- a/debian/kano-desktop.install
+++ b/debian/kano-desktop.install
@@ -33,7 +33,7 @@ bin/kano-ui-autostart /usr/bin
 bin/open-me etc/skel/.Rabbithole
 bin/use-the-force usr/bin
 bin/kano-keyboard-hotkeys usr/bin
-bin/enable-power-button
+bin/enable-power-button usr/bin
 
 scripts/* usr/share/kano-desktop/scripts
 

--- a/debian/kano-desktop.install
+++ b/debian/kano-desktop.install
@@ -33,6 +33,7 @@ bin/kano-ui-autostart /usr/bin
 bin/open-me etc/skel/.Rabbithole
 bin/use-the-force usr/bin
 bin/kano-keyboard-hotkeys usr/bin
+bin/enable-power-button
 
 scripts/* usr/share/kano-desktop/scripts
 


### PR DESCRIPTION
The script was missing, which caused the automatic poweroff feature to never work.
Merging right away with your blessing.

@tombettany @radujipa 
