### PR TITLE
Fixed circular dependency with kano-dashboard

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Depends:
     kano-widgets (>=2.2-1),
     kano-applets,
     chromium-browser (>= 41.0),
-    kano-dashboard(>=0.1),
+    kano-dashboard-common (>= 3.10.0-1),
     rpi-chromium-mods-kano,
     chromium
 Replaces: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)


### PR DESCRIPTION
This package seems to only use a binary from kano-dashboard-common
so changing the dependency to said subpackage. kano-dashboard package
already depends on kano-desktop creating a dependency loop.

Depends on: https://github.com/KanoComputing/os-dashboard/pull/325