### PR TITLE
Install alsa config system-wide as well

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Package: kano-desktop
 Architecture: all
 Depends:
     ${misc:Depends},
+    dh-exec,
     openbox (>=3.5.2-4~kano.1),
     kdesk (>=1.4-1),
     kano-wallpapers,

--- a/debian/kano-desktop.install
+++ b/debian/kano-desktop.install
@@ -1,3 +1,5 @@
+#!/usr/bin/dh-exec
+
 icons usr/share/kano-desktop
 images usr/share/kano-desktop
 kdesk usr/share/kano-desktop
@@ -23,6 +25,8 @@ config/console usr/share/kano-desktop/config
 config/sudoers.d/* usr/share/kano-desktop/config/sudoers.d
 
 config/systemd/kano.conf /lib/systemd/system/user@.service.d
+
+config/alsa/.asoundrc => etc/asound.conf
 
 videos usr/share/kano-media
 gtk-themes/Kano usr/share/themes


### PR DESCRIPTION
Previously we used to set the alsa config only per user in their
home folders. This causes issues when we want to use the same
config under root.

This is required for `Overture` in the microphone scene, because the app runs with `sudo` privileges.