### PR TITLE
Added track-ck-type binary which was omitted from the deb install

### DIFF
--- a/debian/kano-desktop.install
+++ b/debian/kano-desktop.install
@@ -38,6 +38,7 @@ bin/open-me etc/skel/.Rabbithole
 bin/use-the-force usr/bin
 bin/kano-keyboard-hotkeys usr/bin
 bin/enable-power-button usr/bin
+bin/track-ck-type usr/bin
 
 scripts/* usr/share/kano-desktop/scripts
 


### PR DESCRIPTION
Completes: https://github.com/KanoComputing/kano-desktop/pull/230/files