### PR TITLE
Enable the power button on demand

### DIFF
--- a/systemd/enable-power-button.service
+++ b/systemd/enable-power-button.service
@@ -5,7 +5,14 @@
 #
 # Unit file to enable any power button that may be connected
 # via a Kano hat.
-
+#
+# There is a startup delay to coordinate with the Dashboard.
+# Make sure to start with this command:
+#
+#  $ systemctl --user start enable-power-button &
+#
+# Subsequent "start" commands will return immediately.
+#
 
 [Unit]
 Description=Enable Power Button
@@ -16,4 +23,6 @@ DefaultDependencies=true
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/bin/sleep 15
 ExecStart=/usr/bin/enable-power-button

--- a/systemd/kano-common.target
+++ b/systemd/kano-common.target
@@ -13,5 +13,4 @@ Description=Kano Common User Services
 IgnoreOnIsolate=true
 Wants=kano-common-tracker.service kano-common-notifications.service \
  kano-boards.service kano-speakerleds.service \
- kano-common-keyboard.service kano-home-button.service track-ck-type.service \
- enable-power-button.service
+ kano-common-keyboard.service kano-home-button.service track-ck-type.service


### PR DESCRIPTION
Do not enable the power button automatically.
Instead, provide the service to be started on demand.
Additionally provide a startup delay to coordinate with it.
