### PR TITLE
Start the notifications daemon during onboarding

### DIFF
--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -76,7 +76,8 @@ initflow=`sudo kano-init status`
 if [ "$initflow" != "disabled" ]; then
 
     # Start the boards daemon so we can talk to hardware periherals during Overture
-    systemctl --user start kano-boards
+    systemctl --user start kano-boards.service
+    systemctl --user start kano-common-notifications.service
 
     # Nothing more to do now, empty desktop behind the overture app
     exit 0


### PR DESCRIPTION
The kano-boards-daemon uses desktop notifications to inform users
of low battery signal on CKC. The daemon was only started before
at the end of onboarding by the kano-common.target. We already
bring up the kano-boards.service after the user is created so
this should not affect anything in principle.