### PR TITLE
Enabling the new screen saver

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-desktop (3.11.0-0) unstable; urgency=low
+
+  * Added new matrix screen saver system wide
+
+ -- Team Kano <dev@kano.me>  Tue, 17 Jul 2017 13:58:37 +0100
+
 kano-desktop (3.10.3-1) unstable; urgency=low
 
   * Doubled audio volume resolution steps

--- a/debian/control
+++ b/debian/control
@@ -31,7 +31,8 @@ Depends:
     chromium-browser (>= 41.0),
     kano-dashboard-common (>= 3.10.0-1),
     rpi-chromium-mods-kano,
-    chromium
+    chromium,
+    qmlmatrix
 Replaces: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Breaks: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Description: The desktop experience of Kanux

--- a/kdesk/.kdeskrc
+++ b/kdesk/.kdeskrc
@@ -26,7 +26,7 @@ table Config
   SoundDisabledIcon: /usr/share/kano-media/sounds/kano_error.wav
 
   ScreenSaverTimeout: 900
-  ScreenSaverProgram: /usr/bin/kdesk-eglsaver
+  ScreenSaverProgram: /usr/bin/qmlmatrix
 
   OneClick: true
   MaximizeSingleton: true

--- a/kdesk/kdeskrc_screensaver
+++ b/kdesk/kdeskrc_screensaver
@@ -1,3 +1,3 @@
   ScreenSaverTimeout: 900
-  ScreenSaverProgram: /bin/true
+  ScreenSaverProgram: /usr/bin/qmlmatrix
   IconHook: /usr/share/kano-desktop/kdesk/icon-hooks.sh


### PR DESCRIPTION
This changeset enables kdesk screen saver across Dashboard mode, which also covers apps started from it. It also updates classic mode to work with the same settings.

This changeset depends on the screen saver PR: https://github.com/KanoComputing/qmlmatrix/pull/1
