### PR TITLE
Adding a Dashboard bootup sound

### DIFF
--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -115,7 +115,8 @@ if [ "$DESKTOP_RUN" -eq 1 ] ; then
     fi
 
     # Play a welcome sound before entering the Dashboard screen
-    aplay "/usr/share/kano-media/sounds/kano_boot_up.wav"
+    welcome_sound="/usr/share/kano-media/sounds/kano_open_app.wav"
+    python -c "from kano.utils import audio; audio.play_sound('$welcome_sound')"
 
 fi
 

--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -114,6 +114,9 @@ if [ "$DESKTOP_RUN" -eq 1 ] ; then
 	sudo kano-updater first-boot
     fi
 
+    # Play a welcome sound before entering the Dashboard screen
+    aplay "/usr/share/kano-media/sounds/kano_boot_up.wav"
+
 fi
 
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-desktop (3.11.1-0) unstable; urgency=low
+
+  * Added a Dashboard bootup welcome sound
+
+ -- Team Kano <dev@kano.me>  Mon, 31 Jul 2017 17:15:00 +0100
+
 kano-desktop (3.11.0-0) unstable; urgency=low
 
   * Added new matrix screen saver system wide

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,15 +1,10 @@
-kano-desktop (3.11.1-0) unstable; urgency=low
-
-  * Added a Dashboard bootup welcome sound
-
- -- Team Kano <dev@kano.me>  Mon, 31 Jul 2017 17:15:00 +0100
-
 kano-desktop (3.11.0-0) unstable; urgency=low
 
   * Added new matrix screen saver system wide
   * Removed enable-power-button script and systemd service
+  * Added a Dashboard bootup welcome sound
 
- -- Team Kano <dev@kano.me>  Wed, 26 Jul 2017 16:47:00 +0100
+ -- Team Kano <dev@kano.me>  Mon, 31 Jul 2017 17:38:00 +0100
 
 kano-desktop (3.10.3-1) unstable; urgency=low
 


### PR DESCRIPTION
The sound is played when loading the Dashboard, only the first time it boots up.

Tested cases:

 * Boot or Reboot from anywhere to go to the Dashboard - sound should play
 * Logout from Dashboard and login back in - sound should not play
 * Click home button from Classic mode - sound should not play
