### PR TITLE
Fixing Dashboard welcome sound

### DIFF
--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -114,8 +114,12 @@ if [ "$DESKTOP_RUN" -eq 1 ] ; then
 	sudo kano-updater first-boot
     fi
 
+    # We need the boards daemon for sound to work correctly
+    systemctl --user start kano-boards.service
+    sleep 5
+
     # Play a welcome sound before entering the Dashboard screen
-    welcome_sound="/usr/share/kano-media/sounds/kano_open_app.wav"
+    welcome_sound="/usr/share/kano-media/sounds/kano_boot_up.wav"
     python -c "from kano.utils import audio; audio.play_sound('$welcome_sound')"
 
 fi

--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -116,7 +116,6 @@ if [ "$DESKTOP_RUN" -eq 1 ] ; then
 
     # We need the boards daemon for sound to work correctly
     systemctl --user start kano-boards.service
-    sleep 5
 
     # Play a welcome sound before entering the Dashboard screen
     welcome_sound="/usr/share/kano-media/sounds/kano_boot_up.wav"


### PR DESCRIPTION
The welcome sound was not heard due to the boards daemon not being yet loaded.
Fixed by force loading it prior to playing the sound.
Also replaced the sound file, as it was mistakenly using the wrong one.

Manual tests PASSED on:

 * RPI with PiHat audio to HDMI
 * RPI naked with audio to HDMI
 * RPI naked with audio to analog

@tombettany 
