### PR TITLE
Fix build issues

### DIFF
--- a/debian/kano-desktop.install
+++ b/debian/kano-desktop.install
@@ -3,7 +3,7 @@ images usr/share/kano-desktop
 kdesk usr/share/kano-desktop
 Legal usr/share/kano-desktop
 
-config/alsa/asound.conf etc/asound.conf
+config/alsa/asound.conf etc
 config/autostart usr/share/kano-desktop/config
 config/chromium usr/share/kano-desktop/config
 config/keyboard/kanokeyboardrc usr/share/kano-desktop/config/keyboard

--- a/debian/kano-desktop.preinst
+++ b/debian/kano-desktop.preinst
@@ -17,3 +17,14 @@ if [ upgrade != "$1" ] \
     dpkg-divert --package kano-desktop --remove --rename \
                 --divert /etc/magic.orig /etc/magic
 fi
+
+
+# In 3.12.0, we removed the installation of the ALSA config file from skel.
+# For some reason, dpkg still thinks it owns the file and it is not removed.
+# Here we remove the file before installing the package, which will then only
+# install the config file under /etc
+if [ upgrade == "$1" ] \
+        && dpkg --compare-versions "$2" lt 3.12; then
+
+    rm -f /etc/skel/.asoundrc
+fi


### PR DESCRIPTION
There were a few issues with where asound.conf was being installed
and a mystery over package ownership of /etc/skel/.asoundrc after
it was removed from the debian install script.