### PR TITLE
Remove the Volume widget in LXPanel in Classic Mode

### DIFF
--- a/config/lxpanel/LXDE/panels/panel
+++ b/config/lxpanel/LXDE/panels/panel
@@ -102,10 +102,6 @@ Plugin {
 }
 
 Plugin {
-    type = volumealsa
-}
-
-Plugin {
     type = space
     Config {
         Size=12


### PR DESCRIPTION
This is necessary because the volume plugin has never heard of the
system ALSA config - /etc/asound.conf and when it doesn't find one
in the user homedir, it creates one from scratch. This breaks our
volume levels and capture channel for the USB microphone. Removing
it until we find a solution to the problem.