### PR TITLE
Remove the Volume widget in LXPanel in Classic Mode

### DIFF
--- a/config/lxpanel/LXDE/panels/panel
+++ b/config/lxpanel/LXDE/panels/panel
@@ -102,10 +102,6 @@ Plugin {
 }
 
 Plugin {
-    type = volumealsa
-}
-
-Plugin {
     type = space
     Config {
         Size=12

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 kano-desktop (3.12.0-0) unstable; urgency=low
 
   * Removed local installation of the ALSA config file
+  * Removed the Volume plugin in LXPanel
 
  -- Team Kano <dev@kano.me>  Fri, 8 Sep 2017 10:48:00 +0100
 


### PR DESCRIPTION
This is necessary because the volume plugin has never heard of the
system ALSA config - /etc/asound.conf and when it doesn't find one
in the user homedir, it creates one from scratch. This breaks our
volume levels and capture channel for the USB microphone. Removing
it until we find a solution to the problem.