### PR TITLE
Added Argentinian Spanish .desktop translation for K > Shutdown

### DIFF
--- a/config/lxpanel/LXDE/panels/panel
+++ b/config/lxpanel/LXDE/panels/panel
@@ -27,25 +27,6 @@ Plugin {
         image=/usr/share/kano-desktop/images/startmenu.png
         system {
         }
-        separator {
-        }
-        item {
-            image=/usr/share/kano-desktop/icons/apps.png
-            name=Apps
-            action=/bin/bash -c "kdesk-hourglass-app kano-apps && /usr/bin/kano-apps"
-        }
-        item {
-            image=/usr/share/kano-desktop/icons/kano-homefolder.png
-            name=Files
-            action=/bin/bash -c "kdesk-hourglass-app pcmanfm && /usr/bin/pcmanfm"
-        }
-        separator {
-        }
-        item {
-        image=/usr/share/kano-desktop/icons/kano-shutdown.png
-        name=Shutdown
-        action=kdesk-blur kano-shutdown
-        }
     }
 }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-desktop (3.9.2-0) unstable; urgency=low
+
+  * Added Argentinian Spanish .desktop translation for K > Shutdown (backport)
+
+ -- Team Kano <dev@kano.me>  Mon, 9 Oct 2017 13:43:00 +0000
+
 kano-desktop (3.9.1-1) unstable; urgency=low
 
   * Added final wallpapers for Argentina locale

--- a/debian/kano-desktop.install
+++ b/debian/kano-desktop.install
@@ -1,6 +1,7 @@
 icons usr/share/kano-desktop
 images usr/share/kano-desktop
 kdesk usr/share/kano-desktop
+kdesk-icon/*.desktop usr/share/applications
 Legal usr/share/kano-desktop
 
 config/alsa/.asound* etc/skel

--- a/kdesk-icon/kano-shutdown.desktop
+++ b/kdesk-icon/kano-shutdown.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Encoding=UTF-8
+Type=Application
+Icon=/usr/share/kano-desktop/icons/kano-shutdown.png
+Exec=kdesk-blur kano-shutdown
+StartupNotify=true
+Name=Shutdown
+Name[es_AR]=Apagar


### PR DESCRIPTION
This change complements the translation changes in lxmenu-data
package. It removes the tree apps in the menu (Apps, Files,
Shutdown) to be specified by the menu layout and it adds the
.desktop spec for kano-shutdown.

**NOTE:** This change is for the 3.9.2 `es_AR` image.