### PR TITLE
Fixed a debian changelog typo

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -43,7 +43,7 @@ kano-desktop (3.10.0-1) unstable; urgency=low
 
  -- Team Kano <dev@kano.me>  Wed, 15 Mar 2017 12:10:00 +0000
 
- kano-desktop (3.9.2-0) unstable; urgency=low
+kano-desktop (3.9.2-0) unstable; urgency=low
 
   * Added Argentinian Spanish .desktop translation for K > Shutdown (backport)
 


### PR DESCRIPTION
Spotted this one randomly whilst looking over some files. I believe I introduced this one when applied the backport to the latest master at the time. Package built just fine without this ever since it seems.