### PR TITLE
Bumped changelog with applied changes from v3.9.2 es_AR backports

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-desktop (3.14.0-0) unstable; urgency=low
+
+  * Applied changes from v3.9.2 es_AR backports to latest
+
+ -- Team Kano <dev@kano.me>  Mon, 16 Oct 2017 15:12:00 +0100
+
 kano-desktop (3.13.0-0) unstable; urgency=low
 
   * Moved generate hw-info event to bg procs


### PR DESCRIPTION
This is to specify that the changes made in the es_AR image need to be rebuilt, tested, and released from master as well.