### PR TITLE
Bootup to Dashboard performance improvements

### DIFF
--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -30,18 +30,6 @@ function track_startup
     if [ "$screen_kit" == "True" ]; then
         kano-tracker-ctl +1 kano_screen_kit
     fi
-
-    if [ is_internet ]; then
-        # Try uploading the tracking data to our servers
-        # Should be quiet on failure
-        kano-sync --upload-tracking-data --silent
-
-        # Sync objects from the content API in the background
-        # TODO: This should be removed once we have the daemon done
-        sudo kano-content sync &
-
-        kano-tracker-ctl +1 'internet-connection-established'
-    fi
 }
 
 

--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -115,9 +115,9 @@ if [ "$COMING_FROM_BOOT" -eq 1 ] ; then
     track_startup
 
     if [ "$FIRST_LOGIN" -eq 1 ] ; then
-	# Finalise account setup
-	logger --id --tag "info" "kano-uixinit first boot"
-	sudo kano-updater first-boot
+        logger --id --tag "info" "kano-uixinit first boot"
+        kano-tracker-ctl generate first-boot &
+        sudo kano-updater first-boot &
     fi
 fi
 

--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -20,24 +20,6 @@
 # $ kano-dashboard-uimode <dashboard | desktop>
 
 
-function track_startup
-{
-    # Report a startup event to Kano Tracker
-    kano-tracker-ctl +1 startup
-
-    # If the kit comes with the Kano Screen Kit, track it
-    screen_kit=`python -c "from kano_settings.system import display; print display.is_screen_kit()"`
-    if [ "$screen_kit" == "True" ]; then
-        kano-tracker-ctl +1 kano_screen_kit
-    fi
-}
-
-
-#
-# Main entry to the script
-#
-
-
 # We want systemd to populate the environment to user services
 # FIXME: MANAGERPID is not exported, SHLVL=2 instead of 1. why?
 export NO_AT_BRIDGE=1
@@ -100,7 +82,11 @@ if [ "$COMING_FROM_BOOT" -eq 1 ] ; then
     # json file
     sudo kano-init finalise || FIRST_LOGIN=0
 
-    track_startup
+    # Report a startup event to Kano Tracker
+    kano-tracker-ctl +1 startup &
+
+    # If the kit comes with the Kano Screen Kit, track it
+    kano-tracker-ctl generate is_screen_kit &
 
     if [ "$FIRST_LOGIN" -eq 1 ] ; then
         logger --id --tag "info" "kano-uixinit first boot"

--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -53,10 +53,10 @@ export FIRST_LOGIN
 systemctl --user import-environment
 
 # We need the home button service for the loading dialog
-systemctl --user start kano-home-button
+systemctl --user start kano-home-button &
 
 # If we are in the middle of the Overture Onboarding, quit now.
-# This means that the Overture app started the X server in the background
+# This means that the Overture app started the X server in the background.
 # TODO: Do we want a special wallpaper here? It will be black, as the overture terminal
 initflow=`sudo kano-init status`
 if [ "$initflow" != "disabled" ]; then
@@ -70,7 +70,7 @@ if [ "$initflow" != "disabled" ]; then
 fi
 
 # This is a standard Xserver login startup, popup the loading message dialog
-kano-home-button-visible show_dialog
+kano-home-button-visible show_dialog &
 
 # We need to do special steps if coming from a bootup
 if [ "$COMING_FROM_BOOT" -eq 1 ] ; then
@@ -137,8 +137,8 @@ if [ "$FIRST_LOGIN" -eq 1 ]; then
     # we want to have one unique set of host ssh keys per kano kit.
     # getent format: kanousers:x:1000:user1,user2,user3
     if [ `getent group kanousers | awk '{lng=split($0, array, ",")} END{print lng }'` -eq 1 ]; then
-	logger --id --tag "info" "kano-ui-autostart regenerating ssh host keys"
-	sudo regenerate-ssh-keys &
+        logger --id --tag "info" "kano-ui-autostart regenerating ssh host keys"
+        sudo regenerate-ssh-keys &
     fi
 fi
 
@@ -150,7 +150,7 @@ if [ -e /lib/systemd/system/alsa-restore.service ]; then
     if [ "$ret_val" -ne 0 ]; then
         logger --id --tag "warn" "Failed to restore volume level, ret code: $ret_val"
     else
-	logger --id --tag "info" "Audio volume level was successfully restored"
+        logger --id --tag "info" "Audio volume level was successfully restored"
     fi
 else
     logger --id --tag "warn" "alsa-restore not found, cannott attempt to restore volume level"
@@ -184,4 +184,4 @@ fi
 # Restart user keep-alive services
 # These are running throughout Dashboard and Desktop modes,
 # until the user does a logoff or shutdown
-systemctl --user restart kano-common.target
+systemctl --user restart kano-common.target &

--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -1,21 +1,23 @@
 #!/bin/bash
+
+# kano-ui-autostart
 #
-#  kano-ui-autostart
+# Copyright (C) 2014-2017 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
-#  This is the Kano version of Lightdm autostart script.
-#  It is run everytime the kit boots up, and each time a successful Greeter login takes place.
+# This is the Kano version of Lightdm autostart script.
+# It is run everytime the kit boots up, and each time a successful Greeter login takes place.
 #
-#  It decides wether to go into Dashboard or Desktop mode via systemd services.
-#  Switching takes place by restarting systemd services, which makes it happen very fast.
-#  Look at /usr/lib/systemd/user Kano unit files for more details.
+# It decides whether to go into Dashboard or Desktop mode via systemd services.
+# Switching takes place by restarting systemd services, which makes it happen very fast.
+# Look at /usr/lib/systemd/user Kano unit files for more details.
 #
-#  Finally, this script does most of the old kano-uixinit tasks: mouse, keyboard setup,
-#  disabling screen DPMS, and Kano Tracking.
+# Finally, this script does most of the old kano-uixinit tasks: mouse, keyboard setup,
+# disabling screen DPMS, and Kano Tracking.
 #
-#  To switch from either mode from a terminal or ssh session:
+# To switch from either mode from a terminal or ssh session:
 #
-#  $ kano-dashboard-uimode <dashboard | desktop>
-#
+# $ kano-dashboard-uimode <dashboard | desktop>
 
 
 function track_startup

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,10 @@
 kano-desktop (3.14.0-0) unstable; urgency=low
 
   * Applied changes from v3.9.2 es_AR backports to latest
+  * Bootup to Dashboard performance improvements:
+  *   - First boot async event tracking and Updater routine
 
- -- Team Kano <dev@kano.me>  Mon, 16 Oct 2017 15:12:00 +0100
+ -- Team Kano <dev@kano.me>  Tue, 24 Oct 2017 12:40:00 +0100
 
 kano-desktop (3.13.0-0) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,8 +3,9 @@ kano-desktop (3.14.0-0) unstable; urgency=low
   * Applied changes from v3.9.2 es_AR backports to latest
   * Bootup to Dashboard performance improvements:
   *   - First boot async event tracking and Updater routine
+  *   - Moved kano content and tracking sync to network hooks
 
- -- Team Kano <dev@kano.me>  Tue, 24 Oct 2017 12:40:00 +0100
+ -- Team Kano <dev@kano.me>  Tue, 24 Oct 2017 14:20:00 +0100
 
 kano-desktop (3.13.0-0) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,8 +4,9 @@ kano-desktop (3.14.0-0) unstable; urgency=low
   * Bootup to Dashboard performance improvements:
   *   - First boot async event tracking and Updater routine
   *   - Moved kano content and tracking sync to network hooks
+  *   - Moved 'startup' and 'kano_screen_kit' events to tracker and call async
 
- -- Team Kano <dev@kano.me>  Tue, 24 Oct 2017 14:20:00 +0100
+ -- Team Kano <dev@kano.me>  Tue, 24 Oct 2017 16:56:00 +0100
 
 kano-desktop (3.13.0-0) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,8 +5,9 @@ kano-desktop (3.14.0-0) unstable; urgency=low
   *   - First boot async event tracking and Updater routine
   *   - Moved kano content and tracking sync to network hooks
   *   - Moved 'startup' and 'kano_screen_kit' events to tracker and call async
+  *   - Starting more services in the background to speed up initialisation time
 
- -- Team Kano <dev@kano.me>  Tue, 24 Oct 2017 16:56:00 +0100
+ -- Team Kano <dev@kano.me>  Tue, 24 Oct 2017 18:29:00 +0100
 
 kano-desktop (3.13.0-0) unstable; urgency=low
 


### PR DESCRIPTION
## First boot async event tracking and Updater routine

This moves the `first-boot` event generation out of the Updater
and into the `kano-tracker-ctl generate` and calling the two
binaries asynchronously (with &) to avoid holding up the boot up.

Requires:
https://github.com/KanoComputing/kano-profile/pull/438
https://github.com/KanoComputing/kano-updater/pull/264


## Moved kano content and tracking sync to network hooks

Rather than holding up booting to Dashboard by uploading tracking
data to our servers, move content and tracking sync to networks
hooks.

Requires:
https://github.com/KanoComputing/kano-toolset/pull/259


## Moved 'startup' and 'kano_screen_kit' events to tracker and async

With this change, tracking the `startup` and `kano_screen_kit`
action events are made async. The latter was moved into the
`kano-tracker-ctl generate` given its requirement to check for
the existance of the SK.

Requires:
https://github.com/KanoComputing/kano-profile/pull/439


## Starting more services in the background to speed up initialisation time

More services could have been launched in the background
reducing the time it takes to launch the Dashboard service.

---

**NOTE:** This is a Work In Progress, please do not merge and review incrementally.