### PR TITLE
Force a longer timeout to the bootup animation

### DIFF
--- a/bin/kano-os-loader
+++ b/bin/kano-os-loader
@@ -20,7 +20,7 @@ rm -rf /var/tmp/kano-splash
 mount /proc -t proc /proc
 
 # Launch splash animation in the background, see kano-splash.service
-kano-splash-daemonize boot "/usr/share/kano-desktop/animations/bootup"
+kano-splash-daemonize boot "-t 30 /usr/share/kano-desktop/animations/bootup"
 
 # Give control the actual system init
 exec /sbin/init


### PR DESCRIPTION
Now that splash animations have a timeout, we need to force the bootup animation to stay longer than the 15 seconds default.

This PR plays along with this one: https://github.com/KanoComputing/kano-toolset/pull/269
