### PR TITLE
Fix a regression for the Low Battery on boot feature

### DIFF
--- a/bin/kano-os-loader
+++ b/bin/kano-os-loader
@@ -20,7 +20,9 @@ rm -rf /var/tmp/kano-splash
 mount /proc -t proc /proc
 
 # Launch splash animation in the background, see kano-splash.service
+# Then return the filesystem to Read-Only mode.
 kano-splash-daemonize boot "-t 30 /usr/share/kano-desktop/animations/bootup"
+/bin/mount -o remount,ro /dev/mmcblk0p2 /
 
 # Give control the actual system init
 exec /sbin/init

--- a/debian/changelog
+++ b/debian/changelog
@@ -11,8 +11,9 @@ kano-desktop (3.14.0-0) unstable; urgency=low
   * Added fast bootup animation using kano-splash
   * Matched Chromium icon on the Desktop with the one on Dashboard
   * Change to use kano-start-browser
+  * Fix for low battery signal on boot software regression
 
- -- Team Kano <dev@kano.me>  Mon, 27 Nov 2017 17:40:00 +0100
+ -- Team Kano <dev@kano.me>  Mon, 06 Dec 2017 14:37:00 +0100
 
 kano-desktop (3.13.0-0) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -11,9 +11,8 @@ kano-desktop (3.14.0-0) unstable; urgency=low
   * Added fast bootup animation using kano-splash
   * Matched Chromium icon on the Desktop with the one on Dashboard
   * Change to use kano-start-browser
-  * Fix for low battery signal on boot software regression
 
- -- Team Kano <dev@kano.me>  Mon, 06 Dec 2017 14:37:00 +0100
+ -- Team Kano <dev@kano.me>  Mon, 27 Nov 2017 17:40:00 +0100
 
 kano-desktop (3.13.0-0) unstable; urgency=low
 


### PR DESCRIPTION
The low battery signal on boot feature requires the root file system mounted in Read-Only mode.
Since that guarantees no sdcard corruption.
The introduction of the bootup splash animation broke this condition because it failed to remount the file system in this mode, which is what this PR fixes.

Accompanied by this PR to be able to stress test it: https://github.com/KanoComputing/kano-peripherals/pull/59
