### PR TITLE
Fixed X Screen Saver starting on a new user first boot

### DIFF
--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -55,6 +55,13 @@ systemctl --user import-environment
 # We need the home button service for the loading dialog
 systemctl --user start kano-home-button &
 
+# Disable XServer screen saver time and screen blanking (The display would become black)
+if [ -n "`which xset`" ]; then
+    xset s off
+    xset -dpms
+    xset s noblank
+fi
+
 # If we are in the middle of the Overture Onboarding, quit now.
 # This means that the Overture app started the X server in the background.
 # TODO: Do we want a special wallpaper here? It will be black, as the overture terminal
@@ -106,13 +113,6 @@ mkdir -p "$HOME/.kano-settings"
 
 # Track some information about the hardware used
 kano-tracker-ctl generate hw-info &
-
-# Disable XServer screen saver time and screen blanking (The display would become black)
-if [ -n "`which xset`" ]; then
-    xset s off
-    xset -dpms
-    xset s noblank
-fi
 
 # Calibrates the mouse pointer speed
 /usr/bin/startmouse

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-desktop (3.15.0-0) unstable; urgency=low
+
+  * Fixed eventual black screen saver after onboarding on first boot
+
+ -- Team Kano <dev@kano.me>  Thu, 21 Dec 2017 10:45:00 +0100
+
 kano-desktop (3.14.0-0) unstable; urgency=low
 
   * Prevent screensaver from covering youtube player


### PR DESCRIPTION
The issue was that the code for disabling the X Screen Saver was
below the point where the script exited quickly when the Overture
onboarding was running. Moving these lines above will ensure that
the X Screen Saver does not start before ours blanking the screen
entirely on the first boot.