### PR TITLE
Disable DPMS from a central code point, lightdm startup script

### DIFF
--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -55,13 +55,6 @@ systemctl --user import-environment
 # We need the home button service for the loading dialog
 systemctl --user start kano-home-button &
 
-# Disable XServer screen saver time and screen blanking (The display would become black)
-if [ -n "`which xset`" ]; then
-    xset s off
-    xset -dpms
-    xset s noblank
-fi
-
 # If we are in the middle of the Overture Onboarding, quit now.
 # This means that the Overture app started the X server in the background.
 # TODO: Do we want a special wallpaper here? It will be black, as the overture terminal

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ kano-desktop (3.15.0-0) unstable; urgency=low
 
   * Fixed eventual black screen saver after onboarding on first boot
 
- -- Team Kano <dev@kano.me>  Thu, 21 Dec 2017 10:45:00 +0100
+ -- Team Kano <dev@kano.me>  Wed, 10 Jan 2018 17:58:00 +0100
 
 kano-desktop (3.14.0-0) unstable; urgency=low
 

--- a/scripts/ldm-session-cleanup-script
+++ b/scripts/ldm-session-cleanup-script
@@ -10,6 +10,8 @@
 #  This script is called by lightm when the user logs off
 #  We collect the time the users spent on this session and save it on the tracker
 #
+#  WARNING: This script is run as root, not the interactive user
+#
 
 su - $USER -c "kano-tracker-ctl session end logon-session 0"
 su - $USER -c "kano-tracker-ctl clear"

--- a/scripts/ldm-session-setup-script
+++ b/scripts/ldm-session-setup-script
@@ -2,7 +2,7 @@
 
 # ldm-session-setup-script
 #
-# Copyright (C) 2014,2015 Kano Computing Ltd.
+# Copyright (C) 2014,2015,2018 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 #
 #  https://wiki.ubuntu.com/LightDM
@@ -10,11 +10,20 @@
 #  This script is called by lightm during user logon session
 #  We save the current time here so we can estimate usage timings
 #
+#  WARNING: This script is run as root, not the interactive user
+#
 
 # Tracking of actions, in the background saves ~ 2secs on a RPi2
 su - $USER -c "kano-tracker-ctl clear &"
 su - $USER -c "kano-tracker-ctl new-token &"
 su - $USER -c "kano-tracker-ctl session start logon-session 0 &"
+
+# Disable XServer screen saver time and screen blanking (The display would become black)
+if [ -n "`which xset`" ]; then
+    xset s off
+    xset -dpms
+    xset s noblank
+fi
 
 # zero means proceed with login, anything else will cancel the session
 exit 0


### PR DESCRIPTION
That means the DPMS will be disabled for every user that the Xserver logs in.
Does not cover the Greeter, but I think in this case we actually want it to work, @radujipa ?

 * https://wiki.ubuntu.com/LightDM#Adding_System_Hooks

