### PR TITLE
Re-enabled kano-updater ui boot-window to resume interrupted updates

### DIFF
--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -99,6 +99,10 @@ if [ "$COMING_FROM_BOOT" -eq 1 ] ; then
         logger --id --tag "info" "kano-uixinit first boot"
         kano-tracker-ctl generate first-boot &
         sudo kano-updater first-boot &
+    else
+        # Check whether the Updater was running in the last boot. If so,
+        # resume the update process.
+        sudo kano-updater ui boot-window
     fi
 fi
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,8 +3,9 @@ kano-desktop (3.15.0-0) unstable; urgency=low
   * Fixed eventual black screen saver after onboarding on first boot
   * Disable the Kano World Widget in Classic Mode
   * Changed the bootup splash to use systemd rather than an init script
+  * Re-enabled kano-updater ui boot-window to resume interrupted updates
 
- -- Team Kano <dev@kano.me>  Thu, 1 Feb 2018 12:48:00 +0100
+ -- Team Kano <dev@kano.me>  Thu, 9 Feb 2018 15:20:00 +0100
 
 kano-desktop (3.14.0-0) unstable; urgency=low
 


### PR DESCRIPTION
This will call the Updater to continue from an `INSTALLING_UPDATES` state when an update is interrupted. In conjunction with `kano-os-recovery`, this will attempt to restore the system to a clean working state.