### PR TITLE
Stop the boot loading indicator if resuming update installation

### DIFF
--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -76,9 +76,6 @@ if [ "$initflow" != "disabled" ]; then
     exit 0
 fi
 
-# This is a standard Xserver login startup, popup the loading animation
-kano-splash-daemonize dashboard -b 0 loader-animation
-
 # We need to do special steps if coming from a bootup
 if [ "$COMING_FROM_BOOT" -eq 1 ] ; then
 
@@ -106,6 +103,8 @@ if [ "$COMING_FROM_BOOT" -eq 1 ] ; then
     fi
 fi
 
+# This is a standard Xserver login startup, popup the loading animation
+kano-splash-daemonize dashboard -b 0 loader-animation
 
 # Are we on a RaspberryPI 2 or above?
 is_rpi2_or_above=`python -c "from kano.utils.hardware import has_min_performance,\


### PR DESCRIPTION
After a power failure during an install, the subsequent boot would
launch the Updater but the loading indicator would be over it for
a while until it terminates by itself. This moves the loading
indicator to execute after the Updater.