### PR TITLE
Add fallback script for kano-os-loader in case update gets interrupted.

### DIFF
--- a/bin/kano-os-loader
+++ b/bin/kano-os-loader
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Copyright (C) 2018 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# kano-os-loader
+#
+# This script exists for backwards compatibility in case
+# it failed to be removed from /boot/cmdline.txt
+#
+
+# Give control the actual system init
+exec /sbin/init

--- a/debian/kano-desktop.install
+++ b/debian/kano-desktop.install
@@ -38,6 +38,7 @@ bin/kano-keyboard-hotkeys usr/bin
 bin/kano-track-space usr/bin
 bin/kano-boot-splash usr/bin
 bin/kano-boot-splash-cli usr/bin
+bin/kano-os-loader usr/bin
 
 scripts/* usr/share/kano-desktop/scripts
 


### PR DESCRIPTION
@skarbat found that it's possible by interrupting the updater to be in a situation where
kano-os-loader has been removed from the filesystem but not from `/boot/cmdline.txt`.
Therefore add  a fallback which does nothing.