### PR TITLE
Removed system wide SDL_VIDEODRIVER=rpi envvar

### DIFF
--- a/config/profile/kano-bashrc
+++ b/config/profile/kano-bashrc
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 # kano-bashrc
-# 
+#
 # Copyright (C) 2014,2015 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 #
-# 
+#
 
 # Setting prompt
 PS1='${debian_chroot:+($debian_chroot)}\[\033[01;33m\]\u@\h\[\033[00m\] \[\033[01;34m\]\w \$\[\033[00m\] '
@@ -54,11 +54,6 @@ alias espeak_debug=\\espeak
 if [ `pidof lxsession` ]; then
     export $(cat /proc/$(pidof lxsession)/environ |xargs -0 echo )
 fi
-
-# The default systemd environment will export the X11 bindings for graphic apps.
-# Force SDL to discard this option and use the RPi dispmanX driver instead.
-# Fixes problem if user wants to start SDL apps from ssh or lxterminal.
-export SDL_VIDEODRIVER="rpi"
 
 # Enforce umask so that user files
 # cannot be seen/touched by others

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-desktop (4.0.0-0) unstable; urgency=low
+
+  * Removed system wide SDL_VIDEODRIVER=rpi envvar
+
+ -- Team Kano <dev@kano.me>  Thu, 19 Apr 2018 17:20:00 +0100
+
 kano-desktop (3.15.0-0) unstable; urgency=low
 
   * Fixed eventual black screen saver after onboarding on first boot


### PR DESCRIPTION
On Stretch, having both libsdl1.2 and libsdl2.0 causes an issue
with this envvar as those executables using v1.2 crash and need
the x11 driver.

Requires:
https://github.com/KanoComputing/kano-overworld/pull/711