### PR TITLE
Add touch flipping support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
-.DS_store
+.DS_Store
+._.DS_Store
 *.swp
 *.swo
+*~
+#*
+*#
+.#*

--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -36,8 +36,7 @@ export PYTHONIOENCODING=UTF-8
 
 
 # set up QT and X11 screen rotation
-source /usr/share/kano-peripherals/scripts/set_rotate.sh
-
+systemctl --user start kano-touch-flip.service
 #
 # Is this the first time we are here directly from a bootup?
 #

--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -34,6 +34,10 @@ export XKB_DEFAULT_LAYOUT=`setxkbmap -query | grep layout | awk '{print $2}'`
 # Tell python modules to use UTF-8 on the console for i18n messages to display accurately.
 export PYTHONIOENCODING=UTF-8
 
+
+# set up QT and X11 screen rotation
+source /usr/share/kano-peripherals/scripts/set_rotate.sh
+
 #
 # Is this the first time we are here directly from a bootup?
 #

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
 kano-desktop (4.0.0-0) unstable; urgency=low
 
+  * Added touch flipping support
   * Removed system wide SDL_VIDEODRIVER=rpi envvar
 
  -- Team Kano <dev@kano.me>  Thu, 19 Apr 2018 17:20:00 +0100

--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,8 @@ Depends:
     qmlmatrix,
     kano-splash,
     kano-os-loader,
-    kano-toolset
+    kano-toolset,
+    kano-touch-support
 Replaces: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Breaks: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Description: The desktop experience of Kanux

--- a/features/touch_flipping.feature
+++ b/features/touch_flipping.feature
@@ -1,0 +1,40 @@
+Feature: Touchscreen flipping
+
+    Scenario: The OS boots up to Overture
+        Given An OS which has not booted before
+         When Overture is running
+         Then Touching touch-sensitive elements works
+         
+    Scenario: The OS is flipped and 
+        Given An OS which has booted before
+          And configured for the screen to be flipped
+         When Overture is running (eg, a new user)
+         Then Touching touch-sensitive elements works
+
+    Scenario: The OS is configured not to be flipped
+        Given An OS which has been configured to be flipped
+          And It is configured for the screen no longer to be flipped
+         When Overture is running (eg, a new user)
+         Then Touching touch-sensitive elements works
+
+    Scenario: Dashboard when the OS is configured not to be flipped
+        Given An OS which has not been configured to be flipped
+         When Dashboard is running (eg, a new user)
+         Then Touching touch-sensitive elements works
+
+    Scenario: Classic mode when the OS is configured not to be flipped
+        Given An OS which has not been configured to be flipped
+         When Classic mode is running (eg, a new user)
+         Then Touching touch-sensitive elements works
+
+    Scenario: Dashboard when the OS is configured to be flipped
+        Given An OS which has been configured to be flipped
+         When Dashboard is running (eg, a new user)
+         Then Touching touch-sensitive elements works
+
+    Scenario: Classic mode when the OS is configured to be flipped
+        Given An OS which has been configured to be flipped
+         When Classic mode is running (eg, a new user)
+         Then Touching touch-sensitive elements works
+
+         

--- a/features/touch_flipping.feature
+++ b/features/touch_flipping.feature
@@ -5,7 +5,7 @@ Feature: Touchscreen flipping
          When Overture is running
          Then Touching touch-sensitive elements works
          
-    Scenario: The OS is flipped and 
+    Scenario: The OS is flipped and boots up to Overture
         Given An OS which has booted before
           And configured for the screen to be flipped
          When Overture is running (eg, a new user)

--- a/systemd/user/kano-common.target
+++ b/systemd/user/kano-common.target
@@ -14,4 +14,4 @@ IgnoreOnIsolate=true
 Wants=kano-common-tracker.service kano-common-notifications.service \
  kano-boards.service kano-speakerleds.service \
  kano-common-keyboard.service kano-home-button.service \
- kano-common-track-space.service
+ kano-common-track-space.service kano-touch-flip.service


### PR DESCRIPTION
This PR configures touch flipping for user programs launched by dashboard or classic mode.
It doesn't include overture yet.
It depends on https://github.com/KanoComputing/kano-peripherals/pull/63
