### PR TITLE
Openbox: Increase size of titlebar for touch

### DIFF
--- a/config/openbox/rc.xml
+++ b/config/openbox/rc.xml
@@ -59,7 +59,7 @@
   <animateIconify>yes</animateIconify>
   <font place="ActiveWindow">
     <name>Bariol</name>
-    <size>13</size>
+    <size>22</size>
     <!-- font size in points -->
     <weight>bold</weight>
     <!-- 'bold' or 'normal' -->
@@ -68,7 +68,7 @@
   </font>
   <font place="InactiveWindow">
     <name>Bariol</name>
-    <size>13</size>
+    <size>22</size>
     <!-- font size in points -->
     <weight>bold</weight>
     <!-- 'bold' or 'normal' -->

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ kano-desktop (4.0.0-0) unstable; urgency=low
 
   * Added touch flipping support
   * Removed system wide SDL_VIDEODRIVER=rpi envvar
+  * Increased size of titlebars
 
  -- Team Kano <dev@kano.me>  Thu, 19 Apr 2018 17:20:00 +0100
 


### PR DESCRIPTION
Bump the titlebar size to allow for easier pressing of the touch
buttons.