### PR TITLE
Tuxpaint full screen

### DIFF
--- a/config/tuxpaint/tuxpaintrc
+++ b/config/tuxpaint/tuxpaintrc
@@ -1,0 +1,3 @@
+fullscreen=yes
+native=yes
+

--- a/debian/kano-desktop.install
+++ b/debian/kano-desktop.install
@@ -21,6 +21,7 @@ config/rxvt/x11-rxvt etc/X11/Xresources
 config/gtk-2.0 etc/skel/.config/
 config/dconf etc/skel/.config/
 config/console usr/share/kano-desktop/config
+config/tuxpaint/tuxpaintrc /etc/skel/.tuxpaintrc
 
 config/sudoers.d/* usr/share/kano-desktop/config/sudoers.d
 


### PR DESCRIPTION
This PR adds a config file to make tuxpaint full screen.
The alternative would be to change the command line, but it's in a .app file in the tuxpaint package, so this is the best way without forking tuxpaint.