### PR TITLE
Delay touch button startup until kdesk is ready

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
 kano-desktop (4.0.0-0) unstable; urgency=low
 
+  * Delay touch button appearance, until kdesk is ready
   * Added dependency with Home Directory Content package
   * Added touch flipping support
   * Removed system wide SDL_VIDEODRIVER=rpi envvar

--- a/systemd/user/kano-desktop.service
+++ b/systemd/user/kano-desktop.service
@@ -9,6 +9,9 @@
 # Forcibly closing scratch on termination, because it is sudoed
 # and is misteriously started outside systemd cgroup.
 #
+# On ExecStartPost we launch the touch home button, which guarantees
+# that Classic mode is ready, and the home button can work.
+#
 
 [Unit]
 Description=Kano Desktop Icons
@@ -19,4 +22,5 @@ Conflicts=kano-dashboard.service
 [Service]
 ExecStartPre=/usr/bin/kdesk-hourglass-app "lxpanel"
 ExecStart=/usr/bin/kdesk
+ExecStartPost=/usr/bin/kano-home-button-visible yes
 Environment="KDESK_EGLSAVER_LAYER=5"


### PR DESCRIPTION
Makes sure that the touch home button is availabe only after kdesk, hence Classic mode is ready.
