### PR TITLE
Remove Squeak dependency madness due to Scratch

### DIFF
--- a/config/openbox/rc.xml
+++ b/config/openbox/rc.xml
@@ -765,14 +765,6 @@
     </position>
   </application>
 
-  <!-- Force squeak not to go above the top of the screen.-->
-  <application class="Squeak">
-    <position force="yes">
-        <x>center</x>
-        <y>0</y>
-    </position>
-  </application>
-
 </applications>
 
 </openbox_config>

--- a/debian/kano-desktop.postinst
+++ b/debian/kano-desktop.postinst
@@ -18,8 +18,6 @@ custom_chromium_bookmarks=/usr/share/kano-desktop/config/chromium/initial_bookma
 lxde_autostart=/etc/xdg/lxsession/LXDE/autostart
 custom_lxde_autostart=/usr/share/kano-desktop/config/autostart/autostart
 
-SQUEAKDIR=/usr/share/squeak
-
 ldm_conf=/etc/lightdm/lightdm.conf
 ldm_login=/usr/share/kano-desktop/scripts/ldm-session-setup-script
 ldm_logout=/usr/share/kano-desktop/scripts/ldm-session-cleanup-script
@@ -28,24 +26,6 @@ SUDOERS_DIR=/etc/sudoers.d
 
 case "$1" in
     configure)
-
-        # Install squeak, but only if not present
-        if [ ! -d "$SQUEAKDIR" ]; then
-            SQUEAKURL=http://dev.kano.me/public/squeak.tar.gz
-
-            rm -rf /etc/skel/squeak
-            rm -rf $SQUEAKDIR
-
-            mkdir -p $SQUEAKDIR
-            wget -nv $SQUEAKURL -O tmp.tar.gz
-            tar -zxvf tmp.tar.gz
-            mv squeak/* $SQUEAKDIR
-            rm -r squeak
-            rm tmp.tar.gz
-        fi
-
-        # create the squeak link to /etc/skel
-        ln -s $SQUEAKDIR /etc/skel/
 
         # /etc/skel/.config
         mkdir -p /etc/skel/.config
@@ -127,7 +107,6 @@ case "$1" in
         # Services to start/stop the bootup splash animation
         systemctl enable boot-splash-start
         systemctl enable boot-splash-terminate
-
         ;;
 esac
 

--- a/debian/kano-desktop.postrm
+++ b/debian/kano-desktop.postrm
@@ -23,9 +23,6 @@ ldm_logout=/usr/share/kano-desktop/scripts/ldm-session-cleanup-script
 case "$1" in
     remove|upgrade)
 
-        # Remove squeak, but only from skel
-        rm -rf /etc/skel/squeak
-
         # Revert old openbox config
         if [ -e "$openbox_rc-old" ]; then
             mv $openbox_rc-old $openbox_rc


### PR DESCRIPTION
This removes any config and installation steps to download and
setup squeak manually for Scratch. `scratch2` now does not
depend on the package anymore, so we don't need it anymore.

Moreover, this currently broke because the `.tar.gz` was moved from the public URL.. **NO!**