### PR TITLE
Fix trashcan bin "not supported" error message

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
 kano-desktop (4.0.0-0) unstable; urgency=low
 
+  * Fixed support for the Trashcan bin on the Home Directory folder
   * Delay touch button appearance, until kdesk is ready
   * Added dependency with Home Directory Content package
   * Added touch flipping support

--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,8 @@ Depends:
     kano-os-loader,
     kano-toolset,
     kano-touch-support,
-    kano-os-homedir-content
+    kano-os-homedir-content,
+    gvfs
 Replaces: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Breaks: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
 Description: The desktop experience of Kanux


### PR DESCRIPTION
This PR fixes the problem whereby when you go into the Home Folder and select to view the trashcan, you would get an "operation no supported" error message.

Adding the `gvfs` package seems to resolve the problem. Tested on the PI on most recent image.

