### PR TITLE
Boot Splash: Avoid remounting the filesystem

### DIFF
--- a/bin/kano-boot-splash
+++ b/bin/kano-boot-splash
@@ -10,7 +10,7 @@
 SPLASH_LINK_PATH=/var/cache/kano-desktop/boot_splash.link
 SPLASH_PATH_DEFAULT=/usr/share/kano-desktop/animations/bootup
 
-# read link, and detect failure 
+# read link, and detect failure
 SPLASH_PATH=""
 SPLASH_PATH=$(readlink $SPLASH_LINK_PATH)
 
@@ -19,4 +19,4 @@ if [ "$SPLASH_PATH" = "" ] ; then
     SPLASH_PATH=$SPLASH_PATH_DEFAULT
 fi
 
-/usr/bin/kano-splash-daemonize boot "-t 30 $SPLASH_PATH"
+/usr/bin/kano-start-splash -t 30 $SPLASH_PATH

--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,7 @@ kano-desktop (4.0.0-0) unstable; urgency=low
   * Removed system wide SDL_VIDEODRIVER=rpi envvar
   * Increased size of titlebars
   * Update list of app which prevent screensaver
+  * Don't remount the filesystem when launching boot animation
 
  -- Team Kano <dev@kano.me>  Thu, 21 Jun 2018 17:20:00 +0100
 

--- a/systemd/system/boot-splash-start.service
+++ b/systemd/system/boot-splash-start.service
@@ -13,13 +13,9 @@ After=kano-os-loader.service
 
 [Service]
 StandardOutput=journal
-Type=forking
 Restart=no
 RemainAfterExit=yes
-ExecStartPre=/bin/mount -o remount,rw /dev/mmcblk0p2 /
-ExecStartPre=-/bin/bash -c "/bin/rm /var/tmp/kano-splash/name-boot"
 ExecStart=/usr/bin/kano-boot-splash
-ExecStop=/usr/bin/kano-stop-splash boot
 TimeoutSec=0
 
 [Install]

--- a/systemd/system/boot-splash-terminate.service
+++ b/systemd/system/boot-splash-terminate.service
@@ -11,7 +11,7 @@ After=multi-user.target graphical.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/kano-stop-splash boot
+ExecStart=/bin/systemctl stop boot-splash-start.service
 Restart=no
 RemainAfterExit=yes
 


### PR DESCRIPTION
Eliminate the need to perform a risky filesystem remount by shifting the
SystemD service to handling the lifetime of the boot animation rather
than having to write something to the filesystem.

Note doesn't definitely solve the boot-up freeze issue (although after many reboots I've not had the problem) but it at least removes one sketchy thing that we do at boot which may cause problems.