### PR TITLE
Remove kano-splash loading anim, handled by dash supervisor

### DIFF
--- a/bin/kano-boot-splash
+++ b/bin/kano-boot-splash
@@ -8,7 +8,10 @@
 # Execute boot splash via symlink
 
 SPLASH_LINK_PATH=/var/cache/kano-desktop/boot_splash.link
-SPLASH_PATH_DEFAULT=/usr/share/kano-desktop/animations/bootup
+
+# FIXME: Using an animated splash here may freeze the kit during bootup.
+#SPLASH_PATH_DEFAULT=/usr/share/kano-desktop/animations/bootup
+SPLASH_PATH_DEFAULT=/usr/share/kano-desktop/animations/bootup/kano_bootup_00020.png
 
 # read link, and detect failure
 SPLASH_PATH=""

--- a/bin/kano-ui-autostart
+++ b/bin/kano-ui-autostart
@@ -107,13 +107,10 @@ if [ "$COMING_FROM_BOOT" -eq 1 ] ; then
     fi
 fi
 
-# This is a standard Xserver login startup, popup the loading animation
-kano-splash-daemonize dashboard -b 0 loader-animation
 
 # Are we on a RaspberryPI 2 or above?
 is_rpi2_or_above=`python -c "from kano.utils.hardware import has_min_performance,\
 RPI_2_B_SCORE ; print has_min_performance(RPI_2_B_SCORE)"`
-
 
 # FIXME: is this still needed?
 mkdir -p "$HOME/.kano-settings"

--- a/debian/changelog
+++ b/debian/changelog
@@ -7,8 +7,9 @@ kano-desktop (4.0.0-0) unstable; urgency=low
   * Increased size of titlebars
   * Update list of app which prevent screensaver
   * Don't remount the filesystem when launching boot animation
+  * Fix low chance of bootup freezing due to animated bootup and spinner
 
- -- Team Kano <dev@kano.me>  Thu, 21 Jun 2018 17:20:00 +0100
+ -- Team Kano <dev@kano.me>  Wed, 18 Jul 2018 15:20:00 +0100
 
 kano-desktop (3.15.0-0) unstable; urgency=low
 


### PR DESCRIPTION
Launching it a second time here:
https://github.com/KanoComputing/os-dashboard/blob/master/bin/kano-dashboard-supervisor#L126