### PR TITLE
[OS-310] Config: Install Openbox configuration link to /etc/skel

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 kano-desktop (4.1.0-0) unstable; urgency=low
 
   * Remove RPi2 checks to either startup to Dashboard or Desktop
+  * Add openbox config to /etc/skel
 
  -- Team Kano <dev@kano.me>  Mon, 13 Aug 2018 12:49:00 +0100
 

--- a/debian/kano-desktop.links
+++ b/debian/kano-desktop.links
@@ -1,0 +1,1 @@
+usr/share/kano-desktop/openbox etc/skel/.config/openbox


### PR DESCRIPTION
Allow the Openbox configuration to be updated by adding it to the
`/etc/skel` directory.