### PR TITLE
[OS-543] Reverse dependency on kano-desktop, fix dependency loop

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-desktop (4.2.1-0) unstable; urgency=low
+
+  * Reversed kano-notifications dependency on kano-desktop, fix dependency loop
+
+ -- Team Kano <dev@kano.me>  Tue, 22 Jan 2019 11:30:00 +0000
+
 kano-desktop (4.2.0-0) unstable; urgency=low
 
   * Updated the Privacy Policy file in user's home folder

--- a/debian/control
+++ b/debian/control
@@ -37,9 +37,15 @@ Depends:
     kano-os-loader,
     kano-toolset,
     kano-touch-support,
-    kano-os-homedir-content
-Replaces: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
-Breaks: kano-settings (<< 1.1-1.20140512build2), kano-feedback (<< 1.1-3)
+    kano-os-homedir-content,
+    kano-notifications (>= 4.2.1)
+Replaces: 
+    kano-settings (<< 1.1-1.20140512build2), 
+    kano-feedback (<< 1.1-3)
+Breaks: 
+    kano-settings (<< 1.1-1.20140512build2), 
+    kano-feedback (<< 1.1-3),
+    kano-notifications (<< 4.2.1)
 Description: The desktop experience of Kanux
  This package contains a variety of configuration files and resources that
  make up the whole KANO desktop experience on top of LXDE.


### PR DESCRIPTION
Full documentation in Confluence - [Fixing the Dependency Tree](https://kanocomputing.atlassian.net/wiki/spaces/OS/pages/99254331/Fixing+the+Dependency+Tree)

Used case #2 in https://wiki.debian.org/PackageTransition

Requires: https://github.com/KanoComputing/os-dashboard/pull/386