### PR TITLE
[OS-1001] Adding systemd timer to refresh Kano World token

### DIFF
--- a/bin/kano-refresh-token
+++ b/bin/kano-refresh-token
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2018 Kano Computing Ltd.
+# Copyright (C) 2019 Kano Computing Ltd.
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 # kano-refresh-token
@@ -27,17 +27,15 @@ if __name__ == '__main__':
     w = mercury.KanoWorld()
     logged_in = w.is_logged_in(True)
     if logged_in:
-        rc = 0
-        print('user is logged in, no action required')
-    else:
-        if not os.path.isfile(w.data_filename) or not len(w.token):
-            print('user never logged in, no token available')
+        print('user is logged in, refreshing the token')
+        success = w.refresh_token(w.token, True)
+        print(success)
+        if success:
+            rc = 0
+            print('new token: {}'.format(w.token))
         else:
-            print('refreshing token: {}'.format(w.token))
-            success = w.refresh_token(w.token, True)
-            print(success)
-            if success:
-                rc = 0
-                print('new token: {}'.format(w.token))
+            print('error refreshing token')
+    else:
+        print('user is not logged in, nothing to do')
 
     sys.exit(rc)

--- a/bin/kano-refresh-token
+++ b/bin/kano-refresh-token
@@ -8,35 +8,51 @@
 # Python3 script to refresh the Kano World login token, using the new API.
 #
 
+'''
+Command line tool for refreshing the Kano World login token
+
+Usage:
+    kano-refresh-token refresh [--verbose]
+    kano-refresh-token -h | --help
+
+Commands:
+    refresh         Request a token refresh to the server if the user is logged in
+
+Options
+    -v, --verbose   Explain the steps taken
+
+'''
+
+import docopt
 import mercury
 import os
 import sys
 
-from kano.logging import logger
 
-
-def test_refresh():
-    # Not implemented yet
-    pass
+def debug_print(verbose, literal):
+    if verbose:
+        print(literal)
 
 
 if __name__ == '__main__':
 
     rc = 1
+    args = docopt.docopt(__doc__)
+    verbose = True if args['--verbose'] else False
 
     # TODO: add docopt, move out code into a function, implement a test option
-    logger.info('accessing mercury KanoWorld')
+    debug_print(verbose, 'accessing mercury KanoWorld')
     w = mercury.KanoWorld()
     logged_in = w.is_logged_in(True)
     if logged_in:
-        logger.info('user is logged in, refreshing the token')
+        debug_print(verbose, 'user is logged in, refreshing the token')
         success = w.refresh_token(w.token, True)
         if success:
             rc = 0
-            logger.info('new token: {}'.format(w.token))
+            debug_print(verbose, 'new token: {}'.format(w.token))
         else:
-            logger.error('error refreshing token')
+            debug_print(verbose, 'error refreshing token')
     else:
-        logger.info('user is not logged in, nothing to do')
+        debug_print(verbose, 'user is not logged in, nothing to do')
 
     sys.exit(rc)

--- a/bin/kano-refresh-token
+++ b/bin/kano-refresh-token
@@ -12,6 +12,8 @@ import mercury
 import os
 import sys
 
+from kano.logging import logger
+
 
 def test_refresh():
     # Not implemented yet
@@ -23,19 +25,18 @@ if __name__ == '__main__':
     rc = 1
 
     # TODO: add docopt, move out code into a function, implement a test option
-    print('accessing mercury KanoWorld')
+    logger.info('accessing mercury KanoWorld')
     w = mercury.KanoWorld()
     logged_in = w.is_logged_in(True)
     if logged_in:
-        print('user is logged in, refreshing the token')
+        logger.info('user is logged in, refreshing the token')
         success = w.refresh_token(w.token, True)
-        print(success)
         if success:
             rc = 0
-            print('new token: {}'.format(w.token))
+            logger.info('new token: {}'.format(w.token))
         else:
-            print('error refreshing token')
+            logger.error('error refreshing token')
     else:
-        print('user is not logged in, nothing to do')
+        logger.info('user is not logged in, nothing to do')
 
     sys.exit(rc)

--- a/bin/kano-refresh-token
+++ b/bin/kano-refresh-token
@@ -38,7 +38,7 @@ if __name__ == '__main__':
 
     rc = 1
     args = docopt.docopt(__doc__)
-    verbose = True if args['--verbose'] else False
+    verbose = args['--verbose']
 
     # TODO: add docopt, move out code into a function, implement a test option
     debug_print(verbose, 'accessing mercury KanoWorld')

--- a/bin/kano-refresh-token
+++ b/bin/kano-refresh-token
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2018 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# kano-refresh-token
+#
+# Python3 script to refresh the Kano World login token, using the new API.
+#
+
+import mercury
+import os
+import sys
+
+
+def test_refresh():
+    # Not implemented yet
+    pass
+
+
+if __name__ == '__main__':
+
+    rc = 1
+
+    # TODO: add docopt, move out code into a function, implement a test option
+    print('accessing mercury KanoWorld')
+    w = mercury.KanoWorld()
+    logged_in = w.is_logged_in(True)
+    if logged_in:
+        rc = 0
+        print('user is logged in, no action required')
+    else:
+        if not os.path.isfile(w.data_filename) or not len(w.token):
+            print('user never logged in, no token available')
+        else:
+            print('refreshing token: {}'.format(w.token))
+            success = w.refresh_token(w.token, True)
+            print(success)
+            if success:
+                rc = 0
+                print('new token: {}'.format(w.token))
+
+    sys.exit(rc)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 kano-desktop (4.3.0-0) unstable; urgency=low
 
   * Removed master_preferences for Chromium from this project
+  * Added service to automatically refresh Kano World login token
 
  -- Team Kano <dev@kano.me>  Mon, 8 Apr 2019 18:30:00 +0100
 

--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,8 @@ Depends:
     kano-touch-support,
     kano-os-homedir-content,
     kano-notifications (>= 4.2.1),
-    python3-docopt
+    python3-docopt,
+    python-mercury
 Replaces: 
     kano-settings (<< 1.1-1.20140512build2), 
     kano-feedback (<< 1.1-3)

--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,8 @@ Depends:
     kano-toolset,
     kano-touch-support,
     kano-os-homedir-content,
-    kano-notifications (>= 4.2.1)
+    kano-notifications (>= 4.2.1),
+    python3-docopt
 Replaces: 
     kano-settings (<< 1.1-1.20140512build2), 
     kano-feedback (<< 1.1-3)

--- a/debian/kano-desktop.install
+++ b/debian/kano-desktop.install
@@ -40,6 +40,7 @@ bin/kano-track-space usr/bin
 bin/kano-boot-splash usr/bin
 bin/kano-boot-splash-cli usr/bin
 bin/kano-os-loader usr/bin
+bin/kano-refresh-token usr/bin
 
 scripts/* usr/share/kano-desktop/scripts
 

--- a/systemd/user/kano-common-refresh-token.service
+++ b/systemd/user/kano-common-refresh-token.service
@@ -1,0 +1,17 @@
+File Edit Options Buffers Tools Help
+#
+# kano-common-refresh-token.service
+#
+# Invokes the kano-renew-token script to make sure the
+# Kano World login token does not expire.
+#
+# This service file is invoked through the kano-common-refresh-token.timer unit.
+#
+
+[Unit]
+Description=Kano World Token Refresh
+IgnoreOnIsolate=true
+
+[Service]
+ExecStart=-/usr/bin/kano-refresh-token
+Type=forking

--- a/systemd/user/kano-common-refresh-token.service
+++ b/systemd/user/kano-common-refresh-token.service
@@ -13,4 +13,4 @@ IgnoreOnIsolate=true
 
 [Service]
 ExecStart=-/usr/bin/kano-refresh-token
-Type=forking
+Type=oneshot

--- a/systemd/user/kano-common-refresh-token.service
+++ b/systemd/user/kano-common-refresh-token.service
@@ -1,4 +1,3 @@
-File Edit Options Buffers Tools Help
 #
 # kano-common-refresh-token.service
 #

--- a/systemd/user/kano-common-refresh-token.timer
+++ b/systemd/user/kano-common-refresh-token.timer
@@ -1,0 +1,16 @@
+#
+# kano-common-refresh-token.timer
+#
+# Systemd timer service to periodically refresh the Kano World login token.
+#
+# This timer is bound to the kano-common.target file,
+# and it will call the Unit file described below when triggered.
+#
+# Use "systemctl --user list-timers --all" to query the status of this timer.
+#
+
+[Timer]
+OnBootSec=60sec
+OnUnitActiveSec=60min
+
+Unit=kano-common-refresh-token.service

--- a/systemd/user/kano-common.target
+++ b/systemd/user/kano-common.target
@@ -14,4 +14,5 @@ IgnoreOnIsolate=true
 Wants=kano-common-tracker.service kano-common-notifications.service \
  kano-boards.service kano-speakerleds.service \
  kano-common-keyboard.service kano-home-button.service \
- kano-common-track-space.service kano-touch-flip.service
+ kano-common-track-space.service kano-touch-flip.service \
+ kano-common-refresh-token.timer


### PR DESCRIPTION
This PR introduces a periodic systemd service to refresh KW login token.

 - [x] systemd periodic service
 - [x] python3 tool to call mercury refresh_token API
 - [x] a fairly easy mechansim for testing it. 
