### PR TITLE
Fix refresh token script and system trigger

### DIFF
--- a/bin/kano-refresh-token
+++ b/bin/kano-refresh-token
@@ -46,10 +46,10 @@ if __name__ == '__main__':
     logged_in = w.is_logged_in(True)
     if logged_in:
         debug_print(verbose, 'user is logged in, refreshing the token')
-        success = w.refresh_token(w.token, True)
+        success = w.refresh_token(w.get_token(), True)
         if success:
             rc = 0
-            debug_print(verbose, 'new token: {}'.format(w.token))
+            debug_print(verbose, 'new token: {}'.format(w.get_token()))
         else:
             debug_print(verbose, 'error refreshing token')
     else:

--- a/systemd/user/kano-common-refresh-token.service
+++ b/systemd/user/kano-common-refresh-token.service
@@ -12,5 +12,5 @@ Description=Kano World Token Refresh
 IgnoreOnIsolate=true
 
 [Service]
-ExecStart=-/usr/bin/kano-refresh-token
+ExecStart=-/usr/bin/kano-refresh-token refresh
 Type=oneshot


### PR DESCRIPTION
The token refresh timer script had 2 small problems:

 * The Mercury token member was obsoleted by get_token() method
 * The command line syntax needs the "refresh" verb, was missing from system trigger

Tested on the RPi, looks to work fine now.
